### PR TITLE
feat: detect Enhanced Broadcasting streams and warn before playback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ bsconfig.json
 
 # Roku device specific configs
 bsconfig.local.json
+
+# Local developer docs (device credentials, personal config)
+DEV.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,325 @@
+# AGENTS.md
+
+## Project Overview
+
+Stitch Revitalized is a Roku channel (BrightScript/SceneGraph) providing a Twitch viewing experience.
+Language: BrightScript (`.brs`) and BrighterScript (`.bs`). UI layout via SceneGraph XML.
+
+## Build, Lint & Format Commands
+
+```bash
+npm run build        # Compile with BrighterScript (no package)
+npm run watch        # Build with file watching
+npm run package      # Create deployable .zip in out/
+npm run lint         # Run bslint
+npm run lint:fix     # Run bslint with auto-fix
+npm run fmt          # Format all .brs/.bs files in-place
+npm run fmt:check    # Check formatting (fails on diff)
+```
+
+CI runs on PRs: `lint` → `fmt:check` → `package`. All three must pass.
+
+There is no test framework. No unit/integration tests exist.
+
+## Project Structure
+```
+source/                    # BrightScript utilities and entry point
+  main.brs                 # App entry point (roSGScreen bootstrap)
+  constants.brs            # Global constants, design tokens, color palettes
+  utils/                   # Shared utility functions
+    array.brs              # Array utility functions
+    config.brs             # Registry (persistent storage) accessors
+    deviceCapabilities.brs # Device/codec detection (HEVC, AV1, HDR, bitrate)
+    globals.brs            # Simple key-value global state
+    http.brs               # HTTP request wrapper
+    misc.brs               # Helper functions (isValid, formatting, etc.)
+components/                # SceneGraph components (XML + BRS pairs)
+  heroScene.brs/.xml       # Main scene (extends SceneManagerScene), manages auth, nav, scene stack
+  SceneManager/            # Scene management framework
+    SceneManager.brs/.xml  # Base scene manager
+    Group/                 # SceneManagerGroup
+    MessageDialog/         # SceneManagerMessageDialog
+    Overhang/              # SceneManagerOverhang
+    Scene/                 # SceneManagerScene (base class for heroScene)
+    Screen/                # SceneManagerScreen
+    Scripts/               # SceneManagerConfig, SceneManagerUtils
+  Scenes/                  # Full-screen views
+    Following/             # Followed streams grid (default home)
+    Discover/              # Browse/discover content
+    LiveChannels/          # Live channel listings
+    Categories/            # Game/category browser
+    Search/                # Search interface
+    Settings/              # User settings screen
+    ChannelPage/           # Individual channel view
+    GamePage/              # Game/category detail page
+    StreamerChannelPage/   # Streamer profile page
+    VideoPlayer/           # Video playback scene
+    LoginPage/             # OAuth device code login flow
+  Modules/                 # Reusable UI components
+    MenuBar/               # Top horizontal menu bar (Following, Discover, LiveChannels, Categories)
+    FollowedStreamsBar/    # Left sidebar showing followed live streams (with SidebarItem)
+    VideoItem/             # Stream/VOD/clip card with thumbnail, labels, badges
+    Chat/                  # Twitch chat overlay (IRC-based, with ChatJob + EmoteJob)
+    CirclePoster/          # Circular avatar component
+    EmojiLabel/            # Label with inline emoji rendering via regex
+    ChannelMenu/           # Channel action menu overlay
+    StitchVideo/           # Video player wrapper
+    CustomVideo/           # Custom video node extensions
+    VideoErrorHandler/     # User-friendly video error messages
+    GIFPlayer/             # Animated GIF decoder + player (with GIFAnimator, GIFDecoder)
+    TwitchContentNode/     # Extended ContentNode for Twitch data
+  Tasks/                   # Task nodes for async work (API calls, content loading)
+    GetTwitchContent/      # Content-fetching task nodes
+    httpRequest/           # Generic HTTP task node
+    PlayerTask/            # Video player task node
+    twitch-api-sdk/        # Twitch GraphQL API client (monolithic TwitchApiTask.bs)
+  DeepLinking/             # External launch handling
+settings/settings.json     # User-facing settings definitions
+manifest                   # Roku channel metadata (v2.2.0)
+images/                    # UI assets
+fonts/                     # Custom fonts
+locale/                    # i18n translation files
+```
+
+## Architecture Patterns
+
+### SceneGraph Component Pattern
+Every component is an XML + BRS pair. The XML declares the interface, children, and script imports:
+
+```xml
+<component name="MyComponent" extends="Group">
+  <interface>
+    <field id="myField" type="string" />
+  </interface>
+  <children>
+    <!-- Child nodes -->
+  </children>
+  <script type="text/brightscript" uri="MyComponent.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
+</component>
+```
+
+Script dependencies are explicit `<script>` includes in XML — there is no module/import system.
+
+### Task Nodes (Async)
+All network I/O and expensive work runs in Task nodes. Pattern:
+1. Create task: `m.task = CreateObject("roSGNode", "TwitchApiTask")`
+2. Observe response: `m.task.observeField("response", "onResponse")`
+3. Set function + run: `m.task.functionName = "myFunc"` then `m.task.control = "run"`
+
+### Navigation
+Uses a lightweight scene stack in heroScene (`m.footprints`) for back-navigation.
+Scenes are created via `buildNode(name)` and appended/removed from the scene tree.
+Top-level tab switching is handled by `MenuBar` (horizontal menu: Following, Discover, LiveChannels, Categories) via `onMenuSelection()`.
+`FollowedStreamsBar` provides a left sidebar showing live followed streams for quick channel access.
+
+### State Management
+- `m.global` — read-only global node (constants, emote caches, app info)
+- `m.top` — current component's interface fields
+- `m.` — component-scoped variables (set in `init()`, used across subs)
+- Registry (`get_setting()`, `set_setting()`, `get_user_setting()`) — persistent key-value storage
+
+## Code Style
+
+### Naming
+- **Components**: PascalCase — `VideoPlayer`, `ChannelPage`, `TwitchApiTask`
+- **Functions/Subs**: camelCase — `handleContent()`, `onResponse()`, `buildNode()`
+  - Some legacy utility functions use snake_case: `get_setting()`, `set_user_setting()`
+  - Callbacks: `on` prefix — `onMenuSelection()`, `onBackPressed()`, `onEnterChannel()`
+- **Variables**: camelCase — `contentCollection`, `rowItem`, `tokenValid`
+- **Constants/Colors**: Nested associative arrays on `m.global.constants`
+- **Fields (XML)**: camelCase — `contentSelected`, `backPressed`, `exitApp`
+
+### Functions vs Subs
+- `sub` for procedures that return nothing
+- `function` for anything that returns a value
+- Entry points use `sub init()` (called automatically by SceneGraph)
+
+### Null Handling
+BrightScript has no null — use `invalid`. Check before access:
+```brightscript
+if m.task <> invalid
+    response = m.task.response
+end if
+```
+Use optional chaining where available (BrighterScript): `rsp?.status`
+
+### Comments
+- Single-line: `' This is a comment`
+- `?` is shorthand for `print` (used for debug logging throughout)
+- Prefer self-documenting code; comment only for non-obvious logic
+
+### Formatting
+- Formatter: `brighterscript-formatter` with default config (`bsfmt.json` is empty)
+- 4-space indentation
+- No trailing whitespace
+- Run `npm run fmt` before committing
+
+### Error Handling
+- Use `try/catch` for operations that may fail (API parsing, etc.)
+- Always check for `invalid` before accessing nested fields
+- Task nodes should set `m.top.control = "STOP"` when done
+- Video errors use dedicated `VideoErrorHandler` module with user-friendly messages
+
+## Twitch API
+
+- All Twitch communication goes through `TwitchApiTask.bs` via GraphQL
+- Client ID: `ue6666qo983tsx6so1t0vnawi233wa`
+- Auth: Device code flow → OAuth token stored in registry
+- Base URL: `https://gql.twitch.tv/gql` (POST, JSON body with `query` field)
+- Always include `Client-Id` and `Device-ID` headers
+
+## Git Conventions
+
+- Conventional commits: `feat:`, `fix:`, `chore:`, `refactor:`, `perf:`, `docs:`
+- Concise subject line (imperative mood, no period)
+- Never mention AI tooling in commits
+- Never commit `DEV.md` or `bsconfig.json`
+- Do not commit automatically — wait for explicit instruction
+
+## Development Principles
+
+- KISS — keep changes minimal and focused
+- Always prefer clean new code following current Roku/BrightScript/SceneGraph best practices over preserving legacy patterns
+- When prior code conflicts with modern conventions, rewrite rather than copy
+- Work one feature/improvement at a time
+- Bugfixes: fix minimally, never refactor while fixing
+- When you spot something to improve, add it to `TODO.md` with priority
+
+## Key Files to Know
+
+| File | Purpose |
+|---|---|
+| `source/main.brs` | App entry point |
+| `components/heroScene.brs` | Main scene (auth, nav, menu) |
+| `components/Tasks/twitch-api-sdk/TwitchApiTask.bs` | All Twitch API calls |
+| `source/utils/config.brs` | Registry read/write helpers |
+| `source/utils/misc.brs` | Shared utility functions |
+| `source/utils/http.brs` | HTTP request wrapper |
+| `source/constants.brs` | Global constants initialization |
+| `settings/settings.json` | User-facing settings schema |
+| `manifest` | Roku channel metadata and version |
+| `bsconfig.json` | BrighterScript compiler config (gitignored, device-specific) |
+
+## QA & Debugging
+
+**Default target: local simulator (brs-desktop).** Only deploy to the physical TV when explicitly asked.
+
+### Local Simulator (brs-desktop)
+
+BrightScript Simulator (Electron app) running locally. Supports SceneGraph rendering, ECP, debug console, and HTTP sideloading.
+
+- **Sideload port**: 8888 (Digest auth, `rokudev` / `rokudev`)
+- **ECP port**: 8060 (no auth)
+- **Debug console port**: 8085
+
+**Limitations**: Video stream playback may not work (HLS auth/DRM). Not pixel-perfect vs real Roku hardware. Task node limit: 10 concurrent. `StandardMessageDialog` and `SimpleLabel` may render as generic nodes. See **Known brs-engine Quirks** below for additional compatibility issues and required workarounds.
+
+#### Deploy to Simulator
+
+```bash
+# Build, package, and sideload to local simulator
+npm run package && curl -s --max-time 30 --digest -u rokudev:rokudev \
+  -F 'mysubmit=Install' -F 'archive=@out/Stitch-Revitalized-For-Roku.zip' \
+  'http://localhost:8888/plugin_install' -o /dev/null
+```
+
+#### Screenshot Capture (Simulator)
+
+```bash
+# 1. Trigger screenshot
+curl -s --max-time 10 --digest -u rokudev:rokudev \
+  -X POST 'http://localhost:8888/plugin_inspect' \
+  -F 'mysubmit=Screenshot' -o /dev/null
+
+# 2. Download the screenshot
+curl -s --max-time 10 --digest -u rokudev:rokudev \
+  -o /tmp/roku_screenshot.png 'http://localhost:8888/pkgs/dev.png'
+```
+
+Use `mcp_look_at` to analyze the screenshot in-agent.
+
+#### Debug Console (Simulator)
+
+```bash
+# Read current debugger output
+(echo ''; sleep 1) | nc -w 3 localhost 8085 2>&1
+
+# Send debugger commands
+echo 'bt' | nc -w 3 localhost 8085 2>&1
+echo 'var' | nc -w 3 localhost 8085 2>&1
+echo 'cont' | nc -w 3 localhost 8085 2>&1
+```
+
+#### ECP (Simulator)
+
+```bash
+# Device info
+curl -s http://localhost:8060/query/device-info
+
+# Simulate remote key presses
+curl -s -X POST http://localhost:8060/keypress/Select
+curl -s -X POST http://localhost:8060/keypress/Back
+curl -s -X POST http://localhost:8060/keypress/Up
+curl -s -X POST http://localhost:8060/keypress/Down
+curl -s -X POST http://localhost:8060/keypress/Left
+curl -s -X POST http://localhost:8060/keypress/Right
+```
+
+#### Typical QA Cycle (Simulator)
+
+1. Build + deploy: `npm run package` → sideload via curl to localhost:8888
+2. Take screenshot: trigger + download + `mcp_look_at`
+3. Check for crashes: `nc` to localhost:8085, read debugger output
+4. Navigate: ECP keypress commands to localhost:8060
+5. Repeat
+
+#### Known brs-engine Quirks
+
+The brs-desktop simulator uses brs-engine, which has compatibility gaps with real Roku hardware. We maintain a **patched** brs-engine build at `~/github/brs-engine/` with fixes for critical issues. The app also includes defensive workarounds.
+
+**Engine-level issues (fixed in our patched brs-engine build):**
+- RowList/ArrayGrid/PosterGrid `setValue("itemContent", ...)` causes infinite recursion → depth guard added
+- ContentNode parentField notifications cascade unbounded → reentrancy guard added
+
+**App-side workarounds (in our BrightScript code):**
+- **XML `alias` attributes** don't work → use `findNode()` + onChange callbacks instead (see CirclePoster)
+- **`findNode()` for Timer/Animation nodes** may return `invalid` during `init()` → always nil-check before `observeField()`
+- **`boundingRect()`** can throw during deep call stacks → always wrap in `try/catch`
+- **`roRegex` with `\x{HHHH}` Unicode escapes** throws `Range out of order in character class` → wrap in `try/catch`, fall back to plain text
+- **Engine-level errors bypass BrightScript `try/catch`** when thrown during field observer dispatch → catch at the field assignment site, not inside the observer
+
+**Defensive coding patterns:**
+```brightscript
+' Safe assignment to fields with observers that may throw in brs-engine
+sub safeSetField(node as object, field as string, value as dynamic)
+    try
+        node[field] = value
+    catch e
+    end try
+end sub
+
+' Safe boundingRect() access
+try
+    bounds = node.boundingRect()
+catch e
+end try
+
+' Safe findNode() with nil-check
+m.timer = m.top.findNode("timer")
+if m.timer <> invalid then m.timer.observeField("fire", "callback")
+```
+
+**brs-engine build & deploy:**
+```bash
+cd ~/github/brs-engine/packages/scenegraph
+rm -rf ../../node_modules/.cache
+npm run build  # webpack succeeds; tsc step may fail (pre-existing TS errors) — OK
+cp lib/brs-sg.js "/Applications/BrightScript Simulator.app/Contents/Resources/app/app/lib/brs-sg.js"
+```
+
+---
+
+### Physical TV (only when explicitly requested)
+
+Device credentials and all TV deploy/debug/ECP commands are in `DEV.md` (gitignored).

--- a/components/Modules/TwitchContentNode/TwitchContentNode.xml
+++ b/components/Modules/TwitchContentNode/TwitchContentNode.xml
@@ -33,6 +33,8 @@
         <field id="StreamBitrates" type="array" />
         <field id="StreamStickyHttpRedirects" type="array" />
         <field id="lowLatencyStreamsAvailable" type="bool" />
+        <!-- Enhanced Broadcasting detection -->
+        <field id="isTransmux" type="bool" value="false" />
         <!-- Error handling fields -->
         <field id="errorCode" type="string" />
     </interface>

--- a/components/Scenes/VideoPlayer/VideoPlayer.brs
+++ b/components/Scenes/VideoPlayer/VideoPlayer.brs
@@ -852,6 +852,10 @@ sub onTransmuxDialogButton()
 end sub
 
 sub onTransmuxDialogClosed()
+    scene = m.top.getScene()
+    if scene <> invalid
+        scene.dialog = invalid
+    end if
     if m.transmuxButtonIndex = 1
         playContent()
     else

--- a/components/Scenes/VideoPlayer/VideoPlayer.brs
+++ b/components/Scenes/VideoPlayer/VideoPlayer.brs
@@ -48,6 +48,13 @@ sub onResponse()
     ' content.ignoreStreamErrors = true
     m.top.content = m.PlayVideo.response
     m.top.metadata = m.PlayVideo.metadata
+
+    ' Warn before playing Enhanced Broadcasting (transmux) streams
+    if m.top.content <> invalid and m.top.content.isTransmux = true
+        showTransmuxWarning()
+        return
+    end if
+
     playContent()
 end sub
 
@@ -820,6 +827,36 @@ sub onErrorDialogDismissed()
     end if
     m.errorDialog = invalid
     exitPlayer()
+end sub
+
+sub showTransmuxWarning()
+    m.transmuxButtonIndex = -1
+    dialog = createObject("roSGNode", "StandardMessageDialog")
+    dialog.title = "Stream Not Supported"
+    dialog.message = ["This stream uses Twitch Enhanced Broadcasting, a new format that is not yet compatible with Roku.", "", "We're working with Twitch and Roku to fix this."]
+    dialog.buttons = ["Go Back", "Try Anyway"]
+    dialog.observeField("buttonSelected", "onTransmuxDialogButton")
+    dialog.observeField("wasClosed", "onTransmuxDialogClosed")
+    scene = m.top.getScene()
+    if scene <> invalid
+        scene.dialog = dialog
+    end if
+end sub
+
+sub onTransmuxDialogButton()
+    scene = m.top.getScene()
+    if scene <> invalid and scene.dialog <> invalid
+        m.transmuxButtonIndex = scene.dialog.buttonSelected
+        scene.dialog.close = true
+    end if
+end sub
+
+sub onTransmuxDialogClosed()
+    if m.transmuxButtonIndex = 1
+        playContent()
+    else
+        exitPlayer()
+    end if
 end sub
 
 sub onDurationChanged()

--- a/components/Tasks/GetTwitchContent/GetTwitchContent.brs
+++ b/components/Tasks/GetTwitchContent/GetTwitchContent.brs
@@ -563,9 +563,11 @@ sub main()
                     sleep(10)
                     retries++
                 end while
-                variantBody = variantRsp.getString()
-                if variantBody <> invalid and variantBody.InStr("#EXT-X-MAP:") > -1
-                    isTransmux = true
+                if variantRsp <> invalid
+                    variantBody = variantRsp.getString()
+                    if variantBody <> invalid and variantBody.InStr("#EXT-X-MAP:") > -1
+                        isTransmux = true
+                    end if
                 end if
             catch e
             end try

--- a/components/Tasks/GetTwitchContent/GetTwitchContent.brs
+++ b/components/Tasks/GetTwitchContent/GetTwitchContent.brs
@@ -209,7 +209,17 @@ sub main()
             end try
         end if
 
+        ' Detect Enhanced Broadcasting (transmux) from master manifest
+        isTransmux = false
         list = finalPlaylistContent.Split(chr(10))
+        for each manifestLine in list
+            if manifestLine.InStr("#EXT-X-TWITCH-INFO:") = 0 and manifestLine.InStr("TRANSCODESTACK=") > -1
+                if manifestLine.InStr("transmux") > -1
+                    isTransmux = true
+                end if
+            end if
+        end for
+
         fps = invalid
         stream_objects = []
 
@@ -532,6 +542,37 @@ sub main()
             end if
 
             ' ? "[GetTwitchContent] Content node configured with URL: "; content.url
+        end if
+
+        ' Detect fMP4 from the variant playlist if not already flagged via master manifest
+        if not isTransmux and content.url <> invalid and content.url <> ""
+            try
+                variantReq = HttpRequest({
+                    url: content.url,
+                    headers: {
+                        "Accept": "*/*",
+                        "User-Agent": "Mozilla/5.0"
+                    },
+                    method: "GET"
+                })
+                variantRsp = invalid
+                retries = 0
+                while retries < 300
+                    variantRsp = variantReq.send()
+                    if variantRsp <> invalid then exit while
+                    sleep(10)
+                    retries++
+                end while
+                variantBody = variantRsp.getString()
+                if variantBody <> invalid and variantBody.InStr("#EXT-X-MAP:") > -1
+                    isTransmux = true
+                end if
+            catch e
+            end try
+        end if
+
+        if isTransmux
+            content.isTransmux = true
         end if
 
         m.top.metadata = metadata


### PR DESCRIPTION
## Summary

- Detects Twitch Enhanced Broadcasting (EB) streams that use fMP4 with audio-first track ordering — incompatible with Roku's HLS demuxer (error 970)
- Shows a warning dialog before playback: "Stream Not Supported" with Go Back / Try Anyway options
- Detection works for both live streams (`TRANSCODESTACK=transmux` in master manifest) and VODs (`#EXT-X-MAP` in variant playlist)

## Context

Roku's fMP4 HLS demuxer crashes when audio tracks are declared before video tracks in moov/moof boxes. Twitch Enhanced Broadcasting uses this ordering for all HEVC/AV1 streams. Bug reported to both Roku and Twitch — this provides a user-facing warning in the meantime.

## Changes

- **TwitchContentNode.xml**: Added `isTransmux` boolean field
- **GetTwitchContent.brs**: Two-tier EB detection (master manifest scan + variant playlist fMP4 check with 3s timeout)
- **VideoPlayer.brs**: Pre-playback `StandardMessageDialog` with Go Back / Try Anyway, using `wasClosed` observer for reliable dismissal

## Testing

Tested on TCL 50S455 Roku TV (firmware 15.1.3334):
- EB live stream → dialog appears, Go Back exits, Try Anyway proceeds to playback (which then fails with expected error 970)
- EB VOD → dialog appears correctly (detected via variant playlist fMP4 check)
- Non-EB live/VOD → no dialog, normal playback