### PR TITLE
chore: remove redundant transitive deps from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,7 @@
         "": {
             "name": "@jeremy-albinet/stitch-revitalized-for-roku",
             "dependencies": {
-                "@npmcli/fs": "^5.0.0",
-                "@rokucommunity/bslib": "^0.1.1",
-                "brighterscript": "^0.71.0",
-                "bslib": "npm:@rokucommunity/bslib@^0.1.1",
-                "glob": "^13.0.6",
-                "lru-cache": "^11.3.3",
-                "rimraf": "^6.1.3"
+                "brighterscript": "^0.71.0"
             },
             "devDependencies": {
                 "@rokucommunity/bslint": "^0.8.41",
@@ -63,18 +57,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/@npmcli/fs": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
-            "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
-            "license": "ISC",
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/@rokucommunity/bslib": {
@@ -996,13 +978,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/bslib": {
-            "name": "@rokucommunity/bslib",
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@rokucommunity/bslib/-/bslib-0.1.1.tgz",
-            "integrity": "sha512-2ox6EUL+UTtccTbD4dbVjZK3QHa0PHCqpoKMF8lZz9ayzzEP3iVPF8KZR6hOi6bxsIcbGXVjqmtCVkpC4P9SrA==",
-            "license": "MIT"
-        },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1773,23 +1748,6 @@
                 "spawn-command": "0.0.2"
             }
         },
-        "node_modules/glob": {
-            "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "minimatch": "^10.2.2",
-                "minipass": "^7.1.3",
-                "path-scurry": "^2.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-all": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.3.1.tgz",
@@ -1836,42 +1794,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/glob/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "brace-expansion": "^5.0.5"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/globby": {
@@ -2283,15 +2205,6 @@
                 "node": ">=0.6"
             }
         },
-        "node_modules/lru-cache": {
-            "version": "11.3.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-            "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
         "node_modules/luxon": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.2.tgz",
@@ -2370,15 +2283,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/minipass": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
             }
         },
         "node_modules/moment": {
@@ -2633,12 +2537,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/package-json-from-dist": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-            "license": "BlueOak-1.0.0"
-        },
         "node_modules/pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -2672,22 +2570,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/path-scurry": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "lru-cache": "^11.0.0",
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/path-type": {
@@ -2906,25 +2788,6 @@
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/rimraf": {
-            "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
-            "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "glob": "^13.0.3",
-                "package-json-from-dist": "^1.0.1"
-            },
-            "bin": {
-                "rimraf": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/roku-deploy": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
         "lint:fix": "bslint --fix",
         "fmt": "brighterscript-formatter --write '**/*.{brs,bs}'",
         "fmt:check": "brighterscript-formatter --check '**/*.{brs,bs}'"
-
     },
     "devDependencies": {
         "@rokucommunity/bslint": "^0.8.41",
@@ -17,13 +16,7 @@
         "ropm": "^0.11.5"
     },
     "dependencies": {
-        "@npmcli/fs": "^5.0.0",
-        "@rokucommunity/bslib": "^0.1.1",
-        "brighterscript": "^0.71.0",
-        "bslib": "npm:@rokucommunity/bslib@^0.1.1",
-        "glob": "^13.0.6",
-        "lru-cache": "^11.3.3",
-        "rimraf": "^6.1.3"
+        "brighterscript": "^0.71.0"
     },
     "config": {
         "ghooks": {


### PR DESCRIPTION
## Summary

- Removes `glob`, `lru-cache`, `rimraf`, `@npmcli/fs`, `bslib`, and `@rokucommunity/bslib` from `package.json`
- None of these are used directly in source code — they were transitive leaks accumulated via Dependabot bumps and `npm install` side-effects
- `brighterscript` is now the only true direct runtime dependency
- All CI checks (`lint`, `fmt:check`, `package`) pass after removal, with 0 vulnerabilities reported

## Motivation

These pins were causing unnecessary Dependabot churn (the two PRs we just merged were for `glob` and `brace-expansion`, both purely transitive). Removing them means fewer PRs to review and no false signals about our actual dependency surface.