### PR TITLE
chore: add CI/CD workflows for community repo management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,3 +49,16 @@ updates:
 
     labels:
       - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "09:00"
+      timezone: "America/New_York"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,58 @@
+ui-components:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'components/Scenes/**'
+      - 'components/Modules/**'
+      - 'components/SceneManager/**'
+
+twitch-api:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'components/Tasks/twitch-api-sdk/**'
+      - 'components/Tasks/GetTwitchContent/**'
+
+video-playback:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'components/Scenes/VideoPlayer/**'
+      - 'components/Tasks/PlayerTask/**'
+      - 'components/Modules/VideoErrorHandler/**'
+      - 'components/Modules/StitchVideo/**'
+      - 'components/Modules/CustomVideo/**'
+
+chat:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'components/Modules/Chat/**'
+
+navigation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'components/Modules/MenuBar/**'
+      - 'components/Modules/FollowedStreamsBar/**'
+      - 'components/heroScene.brs'
+      - 'components/heroScene.xml'
+
+utilities:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'source/utils/**'
+      - 'source/constants.brs'
+
+config:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'settings/**'
+      - 'manifest'
+
+assets:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'images/**'
+      - 'fonts/**'
+      - 'locale/**'
+
+devops:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v6

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,42 @@
+name: Close stale issues and PRs
+
+on:
+  schedule:
+    - cron: '30 1 * * *' # Daily at 1:30 AM UTC
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 14
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: pinned,help-wanted,good-first-issue
+          exempt-pr-labels: pinned
+
+          exempt-all-assignees: true
+          exempt-all-milestones: true
+
+          stale-issue-message: >
+            This issue has been inactive for 90 days and has been marked as stale.
+            It will be closed in 14 days unless there's new activity.
+            If this is still relevant, please leave a comment or remove the stale label.
+          stale-pr-message: >
+            This PR has been inactive for 30 days and has been marked as stale.
+            It will be closed in 7 days unless there's new activity.
+            If you're still working on this, please comment or push an update.
+          close-issue-message: Closed due to inactivity. Feel free to reopen if still relevant.
+          close-pr-message: Closed due to inactivity. Feel free to reopen if you'd like to continue.
+
+          remove-stale-when-updated: true
+          operations-per-run: 30


### PR DESCRIPTION
## Summary

- **Rename CI workflow**: `pull_requets.yml` → `ci.yml` (fix typo) and add `push` trigger on `main`
- **Stale issues/PRs**: Auto-mark issues stale after 90 days (close after 14 more), PRs after 30 days (close after 7 more). Exempts pinned, help-wanted, good-first-issue, assigned, and milestoned items.
- **PR labeler**: Auto-labels PRs based on changed files — `ui-components`, `twitch-api`, `video-playback`, `chat`, `navigation`, `utilities`, `config`, `assets`, `devops`
- **Dependabot auto-merge**: Auto-squash-merges patch and minor dependency updates after CI passes. Major updates require manual review.
- **Dependabot for GitHub Actions**: Added `github-actions` ecosystem to keep action versions current

## Files Changed

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Renamed from `pull_requets.yml`, added push-to-main trigger |
| `.github/workflows/stale.yml` | New — stale issue/PR management |
| `.github/workflows/labeler.yml` | New — auto-label PRs by file paths |
| `.github/workflows/dependabot-automerge.yml` | New — auto-merge minor/patch dep updates |
| `.github/labeler.yml` | New — label-to-directory mapping config |
| `.github/dependabot.yml` | Added `github-actions` ecosystem |

## Notes

- **Dependabot auto-merge requires** "Allow auto-merge" to be enabled in repo settings (Settings → General → Pull Requests)
- All new workflows use minimal permissions (least privilege)