### PR TITLE
feat: add live stream reconnect watchdog for post-ad freezes

### DIFF
--- a/components/Scenes/VideoPlayer/VideoPlayer.brs
+++ b/components/Scenes/VideoPlayer/VideoPlayer.brs
@@ -279,6 +279,12 @@ function FormatSeconds(seconds as integer) as string
 end function
 
 sub playContent()
+    ' Reset stall tracking on every (re)start so the watchdog doesn't
+    ' compare against a stale position from a previous playback session.
+    m.lastGoodPosition = invalid
+    m.stallSeconds = 0
+    m.reconnectAttempts = 0
+
     ' Clean up existing video node and its observers
     if m.video <> invalid
         m.video.unobserveField("toggleChat")
@@ -576,7 +582,6 @@ sub init()
     m.reconnectCooldownSec = 45
     m.lastReconnectSuccessSec = 0
     m.lastGoodPosition = invalid
-    m.lastPositionTickTime = invalid
     m.stallSeconds = 0
     m.reconnectTimer = invalid
 
@@ -633,13 +638,11 @@ sub onPositionChanged()
     if m.video <> invalid and m.top.contentRequested <> invalid and m.top.contentRequested.contentType = "LIVE"
         if m.lastGoodPosition = invalid
             m.lastGoodPosition = m.video.position
-            m.lastPositionTickTime = CreateObject("roDateTime").AsSeconds()
             m.stallSeconds = 0
             ' If we just reconnected and we see progress, clear cooldown early
             if m.lastReconnectSuccessSec <> 0 then m.lastReconnectSuccessSec = 0
         else if m.video.position > m.lastGoodPosition
             m.lastGoodPosition = m.video.position
-            m.lastPositionTickTime = CreateObject("roDateTime").AsSeconds()
             m.stallSeconds = 0
             ' If we just reconnected and we see progress, clear cooldown early
             if m.lastReconnectSuccessSec <> 0 then m.lastReconnectSuccessSec = 0
@@ -674,7 +677,6 @@ sub onVideoStateChange()
         ' Restart watchdog on successful resume
         if m.top.contentRequested <> invalid and m.top.contentRequested.contentType = "LIVE" and m.watchdogTimer <> invalid
             if m.lastGoodPosition = invalid then m.lastGoodPosition = m.video.position
-            m.lastPositionTickTime = CreateObject("roDateTime").AsSeconds()
             m.stallSeconds = 0
             m.watchdogTimer.control = "start"
         end if
@@ -686,7 +688,6 @@ sub onVideoStateChange()
     if m.top.contentRequested <> invalid and m.top.contentRequested.contentType = "LIVE" and m.watchdogTimer <> invalid
         if m.video.state = "playing"
             if m.lastGoodPosition = invalid then m.lastGoodPosition = m.video.position
-            m.lastPositionTickTime = CreateObject("roDateTime").AsSeconds()
             m.stallSeconds = 0
             m.watchdogTimer.control = "start"
         else
@@ -843,14 +844,12 @@ sub onWatchdogFire()
     ' If position advanced, reset stall tracking
     if m.lastGoodPosition = invalid
         m.lastGoodPosition = m.video.position
-        m.lastPositionTickTime = nowSec
         m.stallSeconds = 0
         return
     end if
 
     if m.video.position > m.lastGoodPosition
         m.lastGoodPosition = m.video.position
-        m.lastPositionTickTime = nowSec
         m.stallSeconds = 0
         return
     end if
@@ -886,6 +885,7 @@ sub beginLiveReconnect(reason as string)
     end for
     if delaySec > 16 then delaySec = 16
 
+    ? "[VideoPlayer] beginLiveReconnect reason="; reason; " attempt="; m.reconnectAttempts; "/"; m.maxReconnectAttempts
     showTemporaryMessage("Reconnecting... (" + m.reconnectAttempts.toStr() + "/" + m.maxReconnectAttempts.toStr() + ")")
 
     if m.watchdogTimer <> invalid
@@ -934,7 +934,6 @@ sub onLiveReconnectResponse()
 
     ' Reset stall tracking
     m.lastGoodPosition = invalid
-    m.lastPositionTickTime = invalid
     m.stallSeconds = 0
 
     ' Restart playback in-place without exiting the scene

--- a/components/Scenes/VideoPlayer/VideoPlayer.brs
+++ b/components/Scenes/VideoPlayer/VideoPlayer.brs
@@ -639,12 +639,10 @@ sub onPositionChanged()
         if m.lastGoodPosition = invalid
             m.lastGoodPosition = m.video.position
             m.stallSeconds = 0
-            ' If we just reconnected and we see progress, clear cooldown early
-            if m.lastReconnectSuccessSec <> 0 then m.lastReconnectSuccessSec = 0
         else if m.video.position > m.lastGoodPosition
             m.lastGoodPosition = m.video.position
             m.stallSeconds = 0
-            ' If we just reconnected and we see progress, clear cooldown early
+            ' Actual forward progress — safe to clear reconnect cooldown
             if m.lastReconnectSuccessSec <> 0 then m.lastReconnectSuccessSec = 0
         end if
     end if
@@ -663,9 +661,6 @@ sub onVideoStateChange()
     ' Handle buffering states
     if m.video.state = "buffering"
         handleBufferingState()
-        if m.watchdogTimer <> invalid
-            m.watchdogTimer.control = "stop"
-        end if
     else if m.lastBufferState = "buffering" and m.video.state = "playing"
         ' Recovered from buffering
         m.errorHandler.callFunc("resetErrorState")
@@ -673,18 +668,11 @@ sub onVideoStateChange()
             m.bufferCheckTimer.control = "stop"
             m.bufferCheckTimer = invalid
         end if
-
-        ' Restart watchdog on successful resume
-        if m.top.contentRequested <> invalid and m.top.contentRequested.contentType = "LIVE" and m.watchdogTimer <> invalid
-            if m.lastGoodPosition = invalid then m.lastGoodPosition = m.video.position
-            m.stallSeconds = 0
-            m.watchdogTimer.control = "start"
-        end if
     end if
 
     m.lastBufferState = m.video.state
 
-    ' Start/stop watchdog based on state (LIVE only)
+    ' Start/stop LIVE watchdog based on video state (single decision point)
     if m.top.contentRequested <> invalid and m.top.contentRequested.contentType = "LIVE" and m.watchdogTimer <> invalid
         if m.video.state = "playing"
             if m.lastGoodPosition = invalid then m.lastGoodPosition = m.video.position
@@ -899,6 +887,14 @@ sub beginLiveReconnect(reason as string)
     m.reconnectTimer.control = "start"
 end sub
 
+sub cleanupReconnectTask()
+    if m.PlayVideo <> invalid
+        m.PlayVideo.unobserveField("response")
+        m.PlayVideo.control = "stop"
+        m.PlayVideo = invalid
+    end if
+end sub
+
 sub doLiveReconnect()
     if m.isExiting then return
 
@@ -906,6 +902,9 @@ sub doLiveReconnect()
         m.reconnectTimer.control = "stop"
         m.reconnectTimer = invalid
     end if
+
+    ' Clean up any prior reconnect task before creating a new one
+    cleanupReconnectTask()
 
     ' Re-fetch playlist/auth via GetTwitchContent
     m.PlayVideo = CreateObject("roSGNode", "GetTwitchContent")
@@ -916,21 +915,31 @@ sub doLiveReconnect()
 end sub
 
 sub onLiveReconnectResponse()
-    if m.isExiting then return
+    if m.isExiting
+        cleanupReconnectTask()
+        return
+    end if
 
     if m.PlayVideo = invalid or m.PlayVideo.response = invalid
+        cleanupReconnectTask()
         beginLiveReconnect("refresh_failed")
         return
     end if
 
     if m.PlayVideo.response.contentType = "ERROR"
+        cleanupReconnectTask()
         beginLiveReconnect("refresh_failed")
         return
     end if
 
+    ' Capture response before cleanup
+    refreshedContent = m.PlayVideo.response
+    refreshedMetadata = m.PlayVideo.metadata
+    cleanupReconnectTask()
+
     ' Apply fresh content + metadata
-    m.top.content = m.PlayVideo.response
-    m.top.metadata = m.PlayVideo.metadata
+    m.top.content = refreshedContent
+    m.top.metadata = refreshedMetadata
 
     ' Reset stall tracking
     m.lastGoodPosition = invalid

--- a/components/Scenes/VideoPlayer/VideoPlayer.brs
+++ b/components/Scenes/VideoPlayer/VideoPlayer.brs
@@ -476,6 +476,21 @@ sub playContent()
 end sub
 
 sub exitPlayer()
+    ' If allowBreak is true, this is a real user/back exit. During internal
+    ' reconnects we set allowBreak=false before calling exitPlayer().
+    if m.allowBreak
+        m.isExiting = true
+    end if
+
+    ' Stop watchdog/reconnect timers
+    if m.watchdogTimer <> invalid
+        m.watchdogTimer.control = "stop"
+    end if
+    if m.reconnectTimer <> invalid
+        m.reconnectTimer.control = "stop"
+        m.reconnectTimer = invalid
+    end if
+
     if m.delayMeasureTimer <> invalid
         m.delayMeasureTimer.control = "stop"
         m.delayMeasureTimer = invalid
@@ -550,6 +565,25 @@ sub init()
     m.bufferCheckTimer = invalid
     m.lastBufferState = ""
     m.bufferStartTime = 0
+
+    ' ===== Robust LIVE stall watchdog / reconnect =====
+    ' Detects the common Twitch post-ad freeze where state stays "playing"
+    ' but position stops advancing. When detected, it re-fetches the Twitch
+    ' playlist/auth (GetTwitchContent) and restarts playback with backoff.
+    m.isExiting = false
+    m.reconnectAttempts = 0
+    m.maxReconnectAttempts = 6
+    m.reconnectCooldownSec = 45
+    m.lastReconnectSuccessSec = 0
+    m.lastGoodPosition = invalid
+    m.lastPositionTickTime = invalid
+    m.stallSeconds = 0
+    m.reconnectTimer = invalid
+
+    m.watchdogTimer = CreateObject("roSGNode", "Timer")
+    m.watchdogTimer.repeat = true
+    m.watchdogTimer.duration = 2 ' seconds
+    m.watchdogTimer.observeField("fire", "onWatchdogFire")
 end sub
 
 sub onToggleChat()
@@ -595,6 +629,23 @@ sub onPositionChanged()
     ' StitchVideo/CustomVideo have their own onPositionChange for UI.
     ' Can be used for global logic if needed, e.g. global bookmarking not tied to UI.
 
+    ' LIVE watchdog: keep track of forward progress (post-ad freezes often stop position)
+    if m.video <> invalid and m.top.contentRequested <> invalid and m.top.contentRequested.contentType = "LIVE"
+        if m.lastGoodPosition = invalid
+            m.lastGoodPosition = m.video.position
+            m.lastPositionTickTime = CreateObject("roDateTime").AsSeconds()
+            m.stallSeconds = 0
+            ' If we just reconnected and we see progress, clear cooldown early
+            if m.lastReconnectSuccessSec <> 0 then m.lastReconnectSuccessSec = 0
+        else if m.video.position > m.lastGoodPosition
+            m.lastGoodPosition = m.video.position
+            m.lastPositionTickTime = CreateObject("roDateTime").AsSeconds()
+            m.stallSeconds = 0
+            ' If we just reconnected and we see progress, clear cooldown early
+            if m.lastReconnectSuccessSec <> 0 then m.lastReconnectSuccessSec = 0
+        end if
+    end if
+
     ' Measure delay every 30 seconds for debugging
     if m.video <> invalid and Int(m.video.position) mod 30 = 0
         measureStreamDelay()
@@ -609,6 +660,9 @@ sub onVideoStateChange()
     ' Handle buffering states
     if m.video.state = "buffering"
         handleBufferingState()
+        if m.watchdogTimer <> invalid
+            m.watchdogTimer.control = "stop"
+        end if
     else if m.lastBufferState = "buffering" and m.video.state = "playing"
         ' Recovered from buffering
         m.errorHandler.callFunc("resetErrorState")
@@ -616,9 +670,29 @@ sub onVideoStateChange()
             m.bufferCheckTimer.control = "stop"
             m.bufferCheckTimer = invalid
         end if
+
+        ' Restart watchdog on successful resume
+        if m.top.contentRequested <> invalid and m.top.contentRequested.contentType = "LIVE" and m.watchdogTimer <> invalid
+            if m.lastGoodPosition = invalid then m.lastGoodPosition = m.video.position
+            m.lastPositionTickTime = CreateObject("roDateTime").AsSeconds()
+            m.stallSeconds = 0
+            m.watchdogTimer.control = "start"
+        end if
     end if
 
     m.lastBufferState = m.video.state
+
+    ' Start/stop watchdog based on state (LIVE only)
+    if m.top.contentRequested <> invalid and m.top.contentRequested.contentType = "LIVE" and m.watchdogTimer <> invalid
+        if m.video.state = "playing"
+            if m.lastGoodPosition = invalid then m.lastGoodPosition = m.video.position
+            m.lastPositionTickTime = CreateObject("roDateTime").AsSeconds()
+            m.stallSeconds = 0
+            m.watchdogTimer.control = "start"
+        else
+            m.watchdogTimer.control = "stop"
+        end if
+    end if
 
     if m.video.state = "finished" and m.allowBreak
         ' ? "[VideoPlayer] Video finished, exiting player."
@@ -752,9 +826,138 @@ sub onBufferTimeout()
     m.bufferCheckTimer = invalid
 end sub
 
+' ===== LIVE stall watchdog / reconnect =====
+sub onWatchdogFire()
+    if m.isExiting then return
+    if m.video = invalid or m.top.contentRequested = invalid then return
+    if m.top.contentRequested.contentType <> "LIVE" then return
+    if m.video.state <> "playing" then return
+
+    nowSec = CreateObject("roDateTime").AsSeconds()
+
+    ' Cooldown after a successful reconnect to avoid immediate re-triggers while Twitch stabilizes
+    if m.lastReconnectSuccessSec <> 0 and (nowSec - m.lastReconnectSuccessSec) < m.reconnectCooldownSec
+        return
+    end if
+
+    ' If position advanced, reset stall tracking
+    if m.lastGoodPosition = invalid
+        m.lastGoodPosition = m.video.position
+        m.lastPositionTickTime = nowSec
+        m.stallSeconds = 0
+        return
+    end if
+
+    if m.video.position > m.lastGoodPosition
+        m.lastGoodPosition = m.video.position
+        m.lastPositionTickTime = nowSec
+        m.stallSeconds = 0
+        return
+    end if
+
+    ' Position didn't advance since last tick
+    m.stallSeconds = m.stallSeconds + 2
+
+    ' Common post-ad freeze: state remains "playing" but position is stuck
+    if m.stallSeconds >= 8
+        ? "[VideoPlayer] LIVE stall detected (pos="; m.video.position; "). Reconnecting..."
+        beginLiveReconnect("stall")
+    end if
+end sub
+
+sub beginLiveReconnect(reason as string)
+    if m.isExiting then return
+
+    ' If a reconnect is already scheduled/in-flight, don't stack them
+    if m.reconnectTimer <> invalid then return
+
+    m.reconnectAttempts = m.reconnectAttempts + 1
+    if m.reconnectAttempts > m.maxReconnectAttempts
+        showErrorDialog("Stream frozen", "Twitch playback froze after an ad and could not be recovered.")
+        m.allowBreak = true
+        exitPlayer()
+        return
+    end if
+
+    ' Exponential backoff: 1,2,4,8,16,16...
+    delaySec = 1
+    for i = 1 to m.reconnectAttempts - 1
+        delaySec = delaySec * 2
+    end for
+    if delaySec > 16 then delaySec = 16
+
+    showTemporaryMessage("Reconnecting... (" + m.reconnectAttempts.toStr() + "/" + m.maxReconnectAttempts.toStr() + ")")
+
+    if m.watchdogTimer <> invalid
+        m.watchdogTimer.control = "stop"
+    end if
+
+    m.reconnectTimer = CreateObject("roSGNode", "Timer")
+    m.reconnectTimer.duration = delaySec
+    m.reconnectTimer.repeat = false
+    m.reconnectTimer.observeField("fire", "doLiveReconnect")
+    m.reconnectTimer.control = "start"
+end sub
+
+sub doLiveReconnect()
+    if m.isExiting then return
+
+    if m.reconnectTimer <> invalid
+        m.reconnectTimer.control = "stop"
+        m.reconnectTimer = invalid
+    end if
+
+    ' Re-fetch playlist/auth via GetTwitchContent
+    m.PlayVideo = CreateObject("roSGNode", "GetTwitchContent")
+    m.PlayVideo.observeField("response", "onLiveReconnectResponse")
+    m.PlayVideo.contentRequested = m.top.contentRequested.getFields()
+    m.PlayVideo.functionName = "main"
+    m.PlayVideo.control = "run"
+end sub
+
+sub onLiveReconnectResponse()
+    if m.isExiting then return
+
+    if m.PlayVideo = invalid or m.PlayVideo.response = invalid
+        beginLiveReconnect("refresh_failed")
+        return
+    end if
+
+    if m.PlayVideo.response.contentType = "ERROR"
+        beginLiveReconnect("refresh_failed")
+        return
+    end if
+
+    ' Apply fresh content + metadata
+    m.top.content = m.PlayVideo.response
+    m.top.metadata = m.PlayVideo.metadata
+
+    ' Reset stall tracking
+    m.lastGoodPosition = invalid
+    m.lastPositionTickTime = invalid
+    m.stallSeconds = 0
+
+    ' Restart playback in-place without exiting the scene
+    m.allowBreak = false
+    exitPlayer()
+    m.allowBreak = true
+    playContent()
+
+    ' Mark successful reconnect (cooldown prevents immediate re-triggers)
+    m.lastReconnectSuccessSec = CreateObject("roDateTime").AsSeconds()
+
+    ' Success -> reset attempt counter and restart watchdog
+    m.reconnectAttempts = 0
+    if m.watchdogTimer <> invalid
+        m.watchdogTimer.control = "start"
+    end if
+end sub
+
 sub retryPlayback()
     ' ? "[VideoPlayer] Retrying playback..."
+    m.allowBreak = false
     exitPlayer()
+    m.allowBreak = true
     playContent()
 end sub
 

--- a/components/Scenes/VideoPlayer/VideoPlayer.brs
+++ b/components/Scenes/VideoPlayer/VideoPlayer.brs
@@ -654,6 +654,8 @@ sub onPositionChanged()
 end sub
 
 sub onVideoStateChange()
+    if m.video = invalid then return
+
     ' This is observed on m.video.
     ' StitchVideo/CustomVideo have their own onVideoStateChange for UI.
     ' ? "[VideoPlayer] Global onVideoStateChange: "; m.video.state
@@ -888,10 +890,10 @@ sub beginLiveReconnect(reason as string)
 end sub
 
 sub cleanupReconnectTask()
-    if m.PlayVideo <> invalid
-        m.PlayVideo.unobserveField("response")
-        m.PlayVideo.control = "stop"
-        m.PlayVideo = invalid
+    if m.reconnectTask <> invalid
+        m.reconnectTask.unobserveField("response")
+        m.reconnectTask.control = "stop"
+        m.reconnectTask = invalid
     end if
 end sub
 
@@ -907,11 +909,11 @@ sub doLiveReconnect()
     cleanupReconnectTask()
 
     ' Re-fetch playlist/auth via GetTwitchContent
-    m.PlayVideo = CreateObject("roSGNode", "GetTwitchContent")
-    m.PlayVideo.observeField("response", "onLiveReconnectResponse")
-    m.PlayVideo.contentRequested = m.top.contentRequested.getFields()
-    m.PlayVideo.functionName = "main"
-    m.PlayVideo.control = "run"
+    m.reconnectTask = CreateObject("roSGNode", "GetTwitchContent")
+    m.reconnectTask.observeField("response", "onLiveReconnectResponse")
+    m.reconnectTask.contentRequested = m.top.contentRequested.getFields()
+    m.reconnectTask.functionName = "main"
+    m.reconnectTask.control = "run"
 end sub
 
 sub onLiveReconnectResponse()
@@ -920,21 +922,21 @@ sub onLiveReconnectResponse()
         return
     end if
 
-    if m.PlayVideo = invalid or m.PlayVideo.response = invalid
+    if m.reconnectTask = invalid or m.reconnectTask.response = invalid
         cleanupReconnectTask()
         beginLiveReconnect("refresh_failed")
         return
     end if
 
-    if m.PlayVideo.response.contentType = "ERROR"
+    if m.reconnectTask.response.contentType = "ERROR"
         cleanupReconnectTask()
         beginLiveReconnect("refresh_failed")
         return
     end if
 
     ' Capture response before cleanup
-    refreshedContent = m.PlayVideo.response
-    refreshedMetadata = m.PlayVideo.metadata
+    refreshedContent = m.reconnectTask.response
+    refreshedMetadata = m.reconnectTask.metadata
     cleanupReconnectTask()
 
     ' Apply fresh content + metadata

--- a/components/Scenes/VideoPlayer/VideoPlayer.brs
+++ b/components/Scenes/VideoPlayer/VideoPlayer.brs
@@ -279,8 +279,9 @@ function FormatSeconds(seconds as integer) as string
 end function
 
 sub playContent()
-    ' Reset stall tracking on every (re)start so the watchdog doesn't
-    ' compare against a stale position from a previous playback session.
+    ' Reset reconnect/watchdog state on every (re)start so stale values
+    ' from a prior playback session don't cause false triggers.
+    m.isExiting = false
     m.lastGoodPosition = invalid
     m.stallSeconds = 0
     m.reconnectAttempts = 0
@@ -488,7 +489,7 @@ sub exitPlayer()
         m.isExiting = true
     end if
 
-    ' Stop watchdog/reconnect timers
+    ' Stop watchdog/reconnect timers and clean up any in-flight reconnect task
     if m.watchdogTimer <> invalid
         m.watchdogTimer.control = "stop"
     end if
@@ -496,6 +497,7 @@ sub exitPlayer()
         m.reconnectTimer.control = "stop"
         m.reconnectTimer = invalid
     end if
+    cleanupReconnectTask()
 
     if m.delayMeasureTimer <> invalid
         m.delayMeasureTimer.control = "stop"
@@ -642,8 +644,6 @@ sub onPositionChanged()
         else if m.video.position > m.lastGoodPosition
             m.lastGoodPosition = m.video.position
             m.stallSeconds = 0
-            ' Actual forward progress — safe to clear reconnect cooldown
-            if m.lastReconnectSuccessSec <> 0 then m.lastReconnectSuccessSec = 0
         end if
     end if
 


### PR DESCRIPTION
## Summary

Adds a reconnect watchdog that detects and recovers from the common Twitch post-ad freeze, where the video state stays "playing" but the position stops advancing.

- **Watchdog timer** fires every 2s during LIVE playback, tracking position progress
- **Stall detection** triggers after 8s of no position advancement
- **Reconnect logic** re-fetches the Twitch playlist/auth via `GetTwitchContent` and restarts playback in-place
- **Exponential backoff** (1→2→4→8→16→16s) with max 6 attempts before showing an error dialog
- **Cooldown** (45s) after successful reconnect to avoid immediate re-triggers while Twitch stabilizes
- `retryPlayback()` now properly guards `exitPlayer()` with `m.allowBreak = false` to prevent exiting the scene during internal retries

All changes are in `VideoPlayer.brs` — no new files, no XML changes.

Split from #38 (reconnect watchdog portion only, excludes recently-watched sidebar).