### PR TITLE
fix: batch bugfixes from PR #39

### DIFF
--- a/components/Tasks/GetTwitchContent/GetTwitchContent.brs
+++ b/components/Tasks/GetTwitchContent/GetTwitchContent.brs
@@ -9,17 +9,6 @@ sub main()
         content = CreateObject("roSGNode", "TwitchContentNode")
         content.setFields(m.top.contentRequested)
 
-        ' Set live stream properties
-        isLowLatencyStream = false
-        if m.top.contentRequested.contentType = "LIVE"
-            if isLowLatencyStream
-                content.streamFormat = "lhls"
-            else
-                content.streamFormat = "hls"
-            end if
-            content.live = true
-        end if
-
         ' Try to get a working clip URL with enhanced method
         workingUrl = findWorkingClipUrl(clipSlug, m.top.contentRequested.previewImageUrl)
 
@@ -90,7 +79,7 @@ sub main()
         end if
 
         ' Check user's latency preference
-        latencyPreference = get_user_setting("preferred.latency", "low")
+        latencyPreference = get_user_setting("preferred.latency", "normal")
         lowLatencyEnabled = (latencyPreference = "low")
 
         ' ? "[GetTwitchContent] ===== LATENCY CONFIGURATION ====="
@@ -161,13 +150,20 @@ sub main()
         })
 
         usher_response = invalid
-        while true
+        maxRetries = 3
+        retryCount = 0
+        while retryCount < maxRetries
             usher_response = req.send()
             if usher_response <> invalid
                 exit while
             end if
-            sleep(10)
+            retryCount++
+            sleep(1000)
         end while
+        if usher_response = invalid
+            m.top.response = invalid
+            return
+        end if
 
         statusCode = usher_response.getResponseCode()
         usher_rsp = usher_response.getString()

--- a/components/heroScene.brs
+++ b/components/heroScene.brs
@@ -106,7 +106,7 @@ function buildNode(name)
     if name <> invalid
         newNode = createObject("roSGNode", name)
         newNode.id = name
-        newNode.translation = "[0, 0]"
+        newNode.translation = [0, 0]
         newNode.observeField("backPressed", "onBackPressed")
         newNode.observeField("contentSelected", "onContentSelected")
         if name <> "GamePage" and name <> "ChannelPage" and name <> "VideoPlayer" and name <> "StreamerChannelPage"
@@ -275,6 +275,5 @@ function onKeyEvent(key, press) as boolean
     '     return true
     ' end if
     if not press then return false
-    ? "KEY EVENT: "; key press
     return false
 end function

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -183,5 +183,12 @@
                 "id": "ASC_followerCount"
             }
         ]
+    },
+    {
+        "title": "Show Followed Streams Sidebar",
+        "description": "Shows or hides the left-side followed streams bar while browsing.",
+        "settingName": "FollowBarOption",
+        "type": "bool",
+        "default": "true"
     }
 ]

--- a/source/constants.brs
+++ b/source/constants.brs
@@ -333,8 +333,8 @@ sub setConstants()
                 magenta: "0xc53dffFF"
             },
             icons: {
-                arrow_down: "pkg:/images/icons/chevron-up.png",
-                arrow_up: "pkg:/images/icons/chevron-down.png",
+                arrow_down: "pkg:/images/icons/chevron-down.png",
+                arrow_up: "pkg:/images/icons/chevron-up.png",
                 back: "pkg:/images/icons/reply.png",
                 login: "pkg:/images/icons/sign-in.png",
                 messages: "pkg:/images/icons/comments.png",

--- a/source/utils/config.brs
+++ b/source/utils/config.brs
@@ -94,8 +94,8 @@ end function
 
 function getTokenFromRegistry()
     return {
-        access_token: get_user_setting("refresh_token", ""),
-        refresh_token: get_user_setting("access_token", ""),
+        access_token: get_user_setting("access_token", ""),
+        refresh_token: get_user_setting("refresh_token", ""),
         login: get_user_setting("login", ""),
         device_id: get_user_setting("device_code", "")
     }

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -323,9 +323,6 @@ sub setTwitchContentFields(twitchContentNode, fields)
     if fields.streamerProfileImageUrl <> invalid
         twitchContentNode.streamerProfileImageUrl = fields.streamerProfileImageUrl
     end if
-    if fields.followerCount <> invalid
-        twitchContentNode.followerCount = fields.followerCount
-    end if
     if fields.gameDisplayName <> invalid
         twitchContentNode.gameDisplayName = fields.gameDisplayName
     end if
@@ -414,7 +411,7 @@ function numberToText(number as object) as object
         r = CreateObject("roRegex", "([0-9]+\.[1-9])|([0-9]+)", "")
         result = r.Match(n)[0] + "K"
     else
-        n = (number / 1000 * 1000).toStr()
+        n = (number / 1000000).toStr()
         r = CreateObject("roRegex", "([0-9]+\.[1-9])|([0-9]+)", "")
         result = r.Match(n)[0] + "M"
     end if


### PR DESCRIPTION
## Summary

Batch of isolated bugfixes cherry-picked from PR #39. Each fix is independent and low-risk.

### Bug Fixes

- **Swapped token keys** (`config.brs`) — `getTokenFromRegistry()` was reading `refresh_token` into `access_token` and vice versa (copy/paste swap)
- **Translation assigned as string** (`heroScene.brs`) — `"[0, 0]"` → `[0, 0]`. BrightScript silently discards string-to-vector2D, so dynamically-built scene nodes started at undefined positions
- **Infinite Usher retry loop** (`GetTwitchContent.brs`) — `while true` + `sleep(10)` (10ms!) replaced with bounded 3-attempt loop with 1s delay; returns `invalid` after exhaustion instead of spinning forever. Also removed dead `isLowLatencyStream` code block and changed default latency preference from `"low"` to `"normal"`
- **Swapped chevron icons** (`constants.brs`) — `arrow_down` pointed up and `arrow_up` pointed down
- **`numberToText` M-suffix math** (`misc.brs`) — `number / 1000 * 1000` (no-op) → `number / 1000000`
- **Dead `followerCount` field** (`misc.brs`) — removed from `setTwitchContentFields` (field no longer exists on TwitchContentNode)
- **Stray debug print** (`heroScene.brs`) — removed `? "KEY EVENT: "; key press`

### Settings

- **Missing `FollowBarOption`** (`settings.json`) — setting was referenced in 3 source files but had no entry in settings.json, so users couldn't see or change it

### Files Changed (6)

- `source/utils/config.brs`
- `components/heroScene.brs`
- `components/Tasks/GetTwitchContent/GetTwitchContent.brs`
- `source/constants.brs`
- `source/utils/misc.brs`
- `settings/settings.json`

Credit: Fixes identified by @awest813 in #39.