### PR TITLE
fix: chat not loading and IRC connection reliability

### DIFF
--- a/components/Modules/Chat/Chat.brs
+++ b/components/Modules/Chat/Chat.brs
@@ -71,16 +71,12 @@ end sub
 
 sub onEnterChannel()
     ' ? "Chat >> onEnterChannel > " m.top.channel
-    if get_user_setting("ChatWebOption", "true") = "true"
-        m.chat = m.top.findnode("ChatJob")
-        m.chat.forceLive = m.top.forceLive
-        ' m.chat.observeField("nextComment", "onNewComment")
-        m.chat.observeField("nextCommentObj", "onNewCommentObj")
-        ' m.chat.observeField("clientComment", "onNewComment")
-        m.chat.channel = m.top.channel
-        m.chat.control = "stop"
-        m.chat.control = "run"
-    end if
+    m.chat = m.top.findnode("ChatJob")
+    m.chat.forceLive = m.top.forceLive
+    m.chat.observeField("nextCommentObj", "onNewCommentObj")
+    m.chat.channel = m.top.channel
+    m.chat.control = "stop"
+    m.chat.control = "run"
     m.EmoteJob = m.top.findnode("EmoteJob")
     m.EmoteJob.channel_id = m.top.channel_id
     m.EmoteJob.channel = m.top.channel

--- a/components/Modules/Chat/ChatJob/ChatJob.brs
+++ b/components/Modules/Chat/ChatJob/ChatJob.brs
@@ -6,19 +6,27 @@ end sub
 sub loginToChat(tcpListen)
     tcpListen.SendStr("CAP REQ :twitch.tv/tags twitch.tv/commands" + Chr(13) + Chr(10))
     user_auth_token = get_user_setting("access_token")
-    m.loggedinUserName = get_user_setting("login")
-    if m.loggedInUsername <> "" and user_auth_token <> invalid and user_auth_token <> ""
-        '? "PASS "
+    m.loggedInUsername = get_user_setting("login")
+    if m.loggedInUsername <> invalid and m.loggedInUsername <> "" and user_auth_token <> invalid and user_auth_token <> ""
         tcpListen.SendStr("PASS oauth:" + user_auth_token + Chr(13) + Chr(10))
-        '? "USER "
-        tcpListen.SendStr("USER " + m.loggedinUsername + " 8 * :" + m.loggedinUsername + Chr(13) + Chr(10))
-        '? "NICK "
-        tcpListen.SendStr("NICK " + m.loggedinUsername + Chr(13) + Chr(10))
+        tcpListen.SendStr("USER " + m.loggedInUsername + " 8 * :" + m.loggedInUsername + Chr(13) + Chr(10))
+        tcpListen.SendStr("NICK " + m.loggedInUsername + Chr(13) + Chr(10))
     else
         tcpListen.SendStr("PASS SCHMOOPIIE" + Chr(13) + Chr(10))
         tcpListen.SendStr("NICK justinfan32006" + Chr(13) + Chr(10))
     end if
 end sub
+
+function reconnectToChat(tcpListen, addr) as object
+    tcpListen.Close()
+    tcpListen = createObject("roStreamSocket")
+    tcpListen.SetSendToAddress(addr)
+    tcpListen.notifyReadable(true)
+    tcpListen.Connect()
+    loginToChat(tcpListen)
+    tcpListen.SendStr("JOIN #" + m.top.channel + Chr(13) + Chr(10))
+    return tcpListen
+end function
 
 sub main()
     ? "[ChatJob] - main"
@@ -54,11 +62,7 @@ sub main()
                 end while
             end if
             if tcpListen.GetCountRcvBuf() = 0 and tcpListen.IsReadable()
-                tcpListen = createObject("roStreamSocket")
-                tcpListen.SetSendToAddress(addr)
-                tcpListen.Connect()
-                loginToChat(tcpListen)
-                tcpListen.SendStr("JOIN #" + m.top.channel + Chr(13) + Chr(10))
+                tcpListen = reconnectToChat(tcpListen, addr)
             end if
             if not received = ""
                 if Left(received, 4) = "PING"
@@ -78,38 +82,50 @@ sub main()
                         ? "Chat Command: "; FormatJson(_parsedMessage, 256)
                     end if
                     if command = "USERNOTICE" or command = "USERSTATE"
-                        ? "pauseable event"
                         sleep(5)
+                    else if command = "RECONNECT"
+                        ? "[ChatJob] Server requested reconnect, reconnecting..."
+                        tcpListen = reconnectToChat(tcpListen, addr)
+                        queue.clear()
+                    else if command = "CLEARMSG" or command = "CLEARCHAT"
+                        ' Discard moderation events — no display_name/message for the renderer
+                        queue.pop()
                     end if
                 end if
-                currentTimestamp = CreateObject("roDateTime").AsSeconds()
-                if _parsedMessage?.tags?.tmi_sent_ts <> invalid
-                    commentTimeStamp = Val(_parsedMessage.tags.tmi_sent_ts.left(10), 10)
-                    commentAge = currentTimestamp - commentTimeStamp
-                    if m.top.forceLive = true
-                        sendWaitingMessage = false
-                        m.top.nextCommentObj = MessageParser(queue.pop())
-                    else if commentAge > m.delay ' measured in seconds
-                        m.top.nextCommentObj = MessageParser(queue.pop())
-                    end if
-                    if sendWaitingMessage <> invalid
-                        if sendWaitingMessage = true
-                            if commentAge >= m.delay
-                                sendWaitingMessage = false
-                                ' m.top.nextCommentObj = MessageParser("display-name=System;user-type= :test!test@test.tmi.twitch.tv PRIVMSG #test :ReSyncing Chat To Stream || ReSyncing Chat To Stream || ReSyncing Chat To Stream || ReSyncing Chat To Stream || ReSyncing Chat To Stream || ReSyncing Chat To Stream || ReSyncing Chat To Stream || ReSyncing Chat To Stream || ReSyncing Chat To Stream  ")
-                            else
-                                if queue[0] <> invalid
-                                    if receivedNewMessage
-                                        m.top.nextCommentObj = MessageParser(queue[0])
-                                        receivedNewMessage = false
+                if queue.count() = 0
+                    ' Skip timestamp processing after RECONNECT cleared the queue
+                    m.top.readyForNextComment = true
+                end if
+                if queue.count() > 0
+                    currentTimestamp = CreateObject("roDateTime").AsSeconds()
+                    if _parsedMessage?.tags?.tmi_sent_ts <> invalid
+                        commentTimeStamp = Val(_parsedMessage.tags.tmi_sent_ts.left(10), 10)
+                        commentAge = currentTimestamp - commentTimeStamp
+                        if m.top.forceLive = true
+                            sendWaitingMessage = false
+                            m.top.nextCommentObj = MessageParser(queue.pop())
+                        else if commentAge > m.delay ' measured in seconds
+                            m.top.nextCommentObj = MessageParser(queue.pop())
+                        end if
+                        if sendWaitingMessage <> invalid
+                            if sendWaitingMessage = true
+                                if commentAge >= m.delay
+                                    sendWaitingMessage = false
+                                    ' m.top.nextCommentObj = MessageParser("display-name=System;user-type= :test!test@test.tmi.twitch.tv PRIVMSG #test :ReSyncing Chat To Stream || ReSyncing Chat To Stream || ReSyncing Chat To Stream || ReSyncing Chat To Stream || ReSyncing Chat To Stream || ReSyncing Chat To Stream || ReSyncing Chat To Stream || ReSyncing Chat To Stream || ReSyncing Chat To Stream  ")
+                                else
+                                    if queue[0] <> invalid
+                                        if receivedNewMessage
+                                            m.top.nextCommentObj = MessageParser(queue[0])
+                                            receivedNewMessage = false
+                                        end if
                                     end if
                                 end if
                             end if
                         end if
+                    else
+                        ' This will discard anything in the queue that doesn't have "tmi-sent-ts"
+                        queue.pop()
                     end if
-                else
-                    ' This will discard anything in the queue that doesn't have "tmi-sent-ts"
-                    queue.pop()
                 end if
             end if
         end while
@@ -324,6 +340,10 @@ function parseCommand(rawCommandComponent)
         }
     else if commandParts[0] = "CLEARMSG" or commandParts[0] = "CLEARCHAT"
         ? "Twitch is requesting a message to be cleared"; formatJSON(commandParts, 256)
+        parsedCommand = {
+            command: commandParts[0],
+            channel: commandParts[1]
+        }
     else if commandParts[0] = "WHISPER"
         ? "WhisperReceived"; formatJSON(commandParts, 256)
     else if commandParts[0] = "421"

--- a/components/Scenes/VideoPlayer/VideoPlayer.brs
+++ b/components/Scenes/VideoPlayer/VideoPlayer.brs
@@ -349,7 +349,7 @@ sub playContent()
         httpAgent.addheader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
         httpAgent.addheader("Client-ID", "kimne78kx3ncx6brgo4mv6wki5h1ko")
         httpAgent.addheader("X-Device-Id", CreateObject("roDeviceInfo").GetRandomUUID())
-        authToken = get_user_setting("auth_token", "")
+        authToken = get_user_setting("access_token", "")
         if authToken <> ""
             httpAgent.addheader("Authorization", "Bearer " + authToken)
         end if

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -44,13 +44,7 @@
         "type": "bool",
         "default": "false"
     },
-    {
-        "title": "Enable Chat Job",
-        "description": "This disables the chat window from sending/receiving web requests.",
-        "settingName": "ChatWebOption",
-        "type": "bool",
-        "default": "false"
-    },
+
     {
         "title": "Chat Font Size",
         "description": "Base font size for chat while watching a stream. Emotes/Badges/Etc scale based on this value.",


### PR DESCRIPTION
## Summary

- **Fix empty chat panel** — chat was showing a black panel with no messages due to two issues:
  1. When not logged in, `get_user_setting("login")` returns `invalid`, which passed the `<> ""` check (BrightScript truthy), sending invalid credentials instead of falling through to the anonymous `justinfan` login path
  2. The `ChatWebOption` setting (which gated the IRC backend) defaulted to `"false"`, so chat never started for users who hadn't explicitly toggled it. Removed this redundant setting entirely — chat visibility is already controlled by `ChatOption`

- **Fix IRC RECONNECT handling** — Twitch sends `RECONNECT` before closing for maintenance; the command was logged but never acted on, causing the chat connection to silently die. Now properly closes the old socket, reconnects, and re-JOINs the channel

- **Fix socket leak on disconnect recovery** — old socket was not closed before creating a new one when the receive buffer was empty and the socket reported readable

- **Fix socket config on reconnect** — `notifyReadable(true)` was missing from reconnected sockets, potentially breaking the read loop

- **Fix CLEARMSG/CLEARCHAT parsing** — `parseCommand()` never assigned `parsedCommand` for these commands, returning `invalid`. Now returns a valid command object. These moderation events are intentionally filtered from the display queue (`queue.pop()`) since the chat renderer expects PRIVMSG-like data — proper moderation event rendering can be added later

- **Fix clip playback auth** — `get_user_setting("auth_token")` used a registry key that doesn't exist; corrected to `"access_token"` which is used everywhere else

- **Remove debug log spam** — removed `"pauseable event"` print that fired on every USERNOTICE/USERSTATE IRC message

- **Code cleanup** — standardized `m.loggedInUsername` casing, extracted `reconnectToChat()` helper shared by both reconnect paths