### PR TITLE
refactor: extract ContentBuilder utility from duplicated row config logic

### DIFF
--- a/components/Scenes/Categories/Categories.brs
+++ b/components/Scenes/Categories/Categories.brs
@@ -88,27 +88,12 @@ function buildRowData(contentCollection)
     rowHeights = []
     ? "Cat CC: "; contentCollection
     for each row in contentCollection.getChildren(contentCollection.getChildCount(), 0)
-        if row.title <> ""
-            hasRowLabel = true
-        else
-            hasRowLabel = false
-        end if
+        hasRowLabel = row.title <> ""
         showRowLabel.push(hasRowLabel)
-        if row.getchild(0).contentType = "LIVE" or row.getchild(0).contentType = "VOD"
-            rowItemSize.push([320, 180])
-            if hasRowLabel
-                rowHeights.push(275)
-            else
-                rowHeights.push(235)
-            end if
-        end if
-        if row.getchild(0).contentType = "GAME"
-            rowItemSize.push([188, 250])
-            if hasRowLabel
-                rowHeights.push(325)
-            else
-                rowHeights.push(305)
-            end if
+        config = getRowConfig(row.getchild(0).contentType, hasRowLabel)
+        if config <> invalid
+            rowItemSize.push(config.itemSize)
+            rowHeights.push(config.rowHeight)
         end if
     end for
     return {

--- a/components/Scenes/Categories/Categories.xml
+++ b/components/Scenes/Categories/Categories.xml
@@ -7,6 +7,7 @@
     </interface>
     <script type="text/brightscript" uri="Categories.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
+    <script type="text/brightscript" uri="pkg:/source/utils/contentBuilder.brs" />
     <children>
         <RowList
             id="homeRowList"

--- a/components/Scenes/ChannelPage/ChannelPage.brs
+++ b/components/Scenes/ChannelPage/ChannelPage.brs
@@ -146,27 +146,12 @@ sub updateRowList(contentCollection)
     showRowLabel = []
     rowHeights = []
     for each row in contentCollection.getChildren(contentCollection.getChildCount(), 0)
-        if row.title <> ""
-            hasRowLabel = true
-        else
-            hasRowLabel = false
-        end if
+        hasRowLabel = row.title <> ""
         showRowLabel.push(hasRowLabel)
-        if row?.getchild(0)?.contentType = "LIVE" or row?.getchild(0)?.contentType = "VOD"
-            rowItemSize.push([320, 180])
-            if hasRowLabel
-                rowHeights.push(275)
-            else
-                rowHeights.push(235)
-            end if
-        end if
-        if row?.getchild(0)?.contentType = "GAME"
-            rowItemSize.push([188, 250])
-            if hasRowLabel
-                rowHeights.push(325)
-            else
-                rowHeights.push(305)
-            end if
+        config = getRowConfig(row?.getchild(0)?.contentType, hasRowLabel)
+        if config <> invalid
+            rowItemSize.push(config.itemSize)
+            rowHeights.push(config.rowHeight)
         end if
     end for
     m.rowList.rowHeights = rowHeights

--- a/components/Scenes/ChannelPage/ChannelPage.brs
+++ b/components/Scenes/ChannelPage/ChannelPage.brs
@@ -147,9 +147,9 @@ sub updateRowList(contentCollection)
     rowHeights = []
     for each row in contentCollection.getChildren(contentCollection.getChildCount(), 0)
         hasRowLabel = row.title <> ""
-        showRowLabel.push(hasRowLabel)
         config = getRowConfig(row?.getchild(0)?.contentType, hasRowLabel)
         if config <> invalid
+            showRowLabel.push(hasRowLabel)
             rowItemSize.push(config.itemSize)
             rowHeights.push(config.rowHeight)
         end if
@@ -158,7 +158,7 @@ sub updateRowList(contentCollection)
     m.rowlist.showRowLabel = showRowLabel
     m.rowlist.rowItemSize = rowItemSize
     m.rowlist.content = contentCollection
-    m.rowlist.numRows = contentCollection.getChildCount()
+    m.rowlist.numRows = rowHeights.count()
 end sub
 
 sub handleItemSelected()

--- a/components/Scenes/ChannelPage/ChannelPage.xml
+++ b/components/Scenes/ChannelPage/ChannelPage.xml
@@ -7,6 +7,7 @@
     </interface>
     <script type="text/brightscript" uri="ChannelPage.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
+    <script type="text/brightscript" uri="pkg:/source/utils/contentBuilder.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
     <children>
         <rectangle id="background" width="1280" height="720" />

--- a/components/Scenes/Discover/Discover.brs
+++ b/components/Scenes/Discover/Discover.brs
@@ -153,27 +153,12 @@ sub updateRowList(jsonContent)
     showRowLabel = []
     rowHeights = []
     for each row in contentCollection.getChildren(contentCollection.getChildCount(), 0)
-        if row.title <> ""
-            hasRowLabel = true
-        else
-            hasRowLabel = false
-        end if
+        hasRowLabel = row.title <> ""
         showRowLabel.push(hasRowLabel)
-        if row.getchild(0).contentType = "LIVE" or row.getchild(0).contentType = "VOD"
-            rowItemSize.push([320, 180])
-            if hasRowLabel
-                rowHeights.push(275)
-            else
-                rowHeights.push(235)
-            end if
-        end if
-        if row.getchild(0).contentType = "GAME"
-            rowItemSize.push([188, 250])
-            if hasRowLabel
-                rowHeights.push(325)
-            else
-                rowHeights.push(305)
-            end if
+        config = getRowConfig(row.getchild(0).contentType, hasRowLabel)
+        if config <> invalid
+            rowItemSize.push(config.itemSize)
+            rowHeights.push(config.rowHeight)
         end if
     end for
     m.rowlist.visible = false

--- a/components/Scenes/Discover/Discover.xml
+++ b/components/Scenes/Discover/Discover.xml
@@ -2,6 +2,7 @@
 <component name="Discover" extends="SceneManagerGroup" initialFocus="homeRowList">
     <script type="text/brightscript" uri="Discover.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
+    <script type="text/brightscript" uri="pkg:/source/utils/contentBuilder.brs" />
     <children>
         <RowList
             id="homeRowList"

--- a/components/Scenes/Following/Following.brs
+++ b/components/Scenes/Following/Following.brs
@@ -235,35 +235,12 @@ sub updateRowList(contentCollection)
     showRowLabel = []
     rowHeights = []
     for each row in contentCollection.getChildren(contentCollection.getChildCount(), 0)
-        if row.title <> ""
-            hasRowLabel = true
-        else
-            hasRowLabel = false
-        end if
+        hasRowLabel = row.title <> ""
         showRowLabel.push(hasRowLabel)
-        if row.getchild(0).contentType = "LIVE" or row.getchild(0).contentType = "VOD"
-            rowItemSize.push([320, 180])
-            if hasRowLabel
-                rowHeights.push(295)
-            else
-                rowHeights.push(255)
-            end if
-        end if
-        if row.getchild(0).contentType = "GAME"
-            rowItemSize.push([188, 250])
-            if hasRowLabel
-                rowHeights.push(325)
-            else
-                rowHeights.push(305)
-            end if
-        end if
-        if row.getchild(0).contentType = "USER"
-            rowItemSize.push([150, 150])
-            if hasRowLabel
-                rowHeights.push(260)
-            else
-                rowHeights.push(240)
-            end if
+        config = getRowConfig(row.getchild(0).contentType, hasRowLabel, true)
+        if config <> invalid
+            rowItemSize.push(config.itemSize)
+            rowHeights.push(config.rowHeight)
         end if
     end for
     m.rowlist.rowHeights = rowHeights

--- a/components/Scenes/Following/Following.xml
+++ b/components/Scenes/Following/Following.xml
@@ -5,6 +5,7 @@
     </interface>
     <script type="text/brightscript" uri="Following.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
+    <script type="text/brightscript" uri="pkg:/source/utils/contentBuilder.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
     <children>
         <Label

--- a/components/Scenes/GamePage/GamePage.brs
+++ b/components/Scenes/GamePage/GamePage.brs
@@ -61,27 +61,12 @@ sub updateRowList(contentCollection)
     showRowLabel = []
     rowHeights = []
     for each row in contentCollection.getChildren(contentCollection.getChildCount(), 0)
-        if row.title <> ""
-            hasRowLabel = true
-        else
-            hasRowLabel = false
-        end if
+        hasRowLabel = row.title <> ""
         showRowLabel.push(hasRowLabel)
-        if row.getchild(0).contentType = "LIVE" or row.getchild(0).contentType = "VOD"
-            rowItemSize.push([320, 180])
-            if hasRowLabel
-                rowHeights.push(275)
-            else
-                rowHeights.push(235)
-            end if
-        end if
-        if row.getchild(0).contentType = "GAME"
-            rowItemSize.push([188, 250])
-            if hasRowLabel
-                rowHeights.push(325)
-            else
-                rowHeights.push(305)
-            end if
+        config = getRowConfig(row.getchild(0).contentType, hasRowLabel)
+        if config <> invalid
+            rowItemSize.push(config.itemSize)
+            rowHeights.push(config.rowHeight)
         end if
     end for
     m.rowList.rowHeights = rowHeights

--- a/components/Scenes/GamePage/GamePage.xml
+++ b/components/Scenes/GamePage/GamePage.xml
@@ -7,6 +7,7 @@
     </interface>
     <script type="text/brightscript" uri="GamePage.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
+    <script type="text/brightscript" uri="pkg:/source/utils/contentBuilder.brs" />
     <children>
         <rectangle id="background" width="1920" height="1080" />
         <SimpleLabel

--- a/components/Scenes/LiveChannels/LiveChannels.brs
+++ b/components/Scenes/LiveChannels/LiveChannels.brs
@@ -84,27 +84,12 @@ function buildRowData(contentCollection)
     rowHeights = []
     ? "Cat CC: "; contentCollection
     for each row in contentCollection.getChildren(contentCollection.getChildCount(), 0)
-        if row.title <> ""
-            hasRowLabel = true
-        else
-            hasRowLabel = false
-        end if
+        hasRowLabel = row.title <> ""
         showRowLabel.push(hasRowLabel)
-        if row.getchild(0).contentType = "LIVE" or row.getchild(0).contentType = "VOD"
-            rowItemSize.push([320, 180])
-            if hasRowLabel
-                rowHeights.push(275)
-            else
-                rowHeights.push(235)
-            end if
-        end if
-        if row.getchild(0).contentType = "GAME"
-            rowItemSize.push([188, 250])
-            if hasRowLabel
-                rowHeights.push(325)
-            else
-                rowHeights.push(305)
-            end if
+        config = getRowConfig(row.getchild(0).contentType, hasRowLabel)
+        if config <> invalid
+            rowItemSize.push(config.itemSize)
+            rowHeights.push(config.rowHeight)
         end if
     end for
     return {

--- a/components/Scenes/LiveChannels/LiveChannels.brs
+++ b/components/Scenes/LiveChannels/LiveChannels.brs
@@ -78,28 +78,7 @@ sub appendMoreRows()
     end if
 end sub
 
-function buildRowData(contentCollection)
-    rowItemSize = []
-    showRowLabel = []
-    rowHeights = []
-    ? "Cat CC: "; contentCollection
-    for each row in contentCollection.getChildren(contentCollection.getChildCount(), 0)
-        hasRowLabel = row.title <> ""
-        showRowLabel.push(hasRowLabel)
-        config = getRowConfig(row.getchild(0).contentType, hasRowLabel)
-        if config <> invalid
-            rowItemSize.push(config.itemSize)
-            rowHeights.push(config.rowHeight)
-        end if
-    end for
-    return {
-        rowHeights: rowHeights,
-        showRowLabel: showRowLabel,
-        rowItemSize: rowItemSize,
-        content: contentCollection,
-        numRows: contentCollection.getChildCount()
-    }
-end function
+
 
 sub updateRowList(content as object)
     if content <> invalid and m.rowList <> invalid

--- a/components/Scenes/LiveChannels/LiveChannels.xml
+++ b/components/Scenes/LiveChannels/LiveChannels.xml
@@ -7,6 +7,7 @@
     </interface>
     <script type="text/brightscript" uri="LiveChannels.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
+    <script type="text/brightscript" uri="pkg:/source/utils/contentBuilder.brs" />
     <children>
         <RowList
             id="homeRowList"

--- a/source/tests/contentBuilder.spec.bs
+++ b/source/tests/contentBuilder.spec.bs
@@ -80,9 +80,16 @@ namespace tests
         @describe("getRowConfig edge cases")
         '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+        @it("returns LIVE/VOD config for CLIP content type")
+        sub clipType()
+            config = getRowConfig("CLIP", true)
+            m.assertEqual(config.itemSize, [320, 180])
+            m.assertEqual(config.rowHeight, 275)
+        end sub
+
         @it("returns invalid for unknown content type")
         sub unknownType()
-            m.assertInvalid(getRowConfig("CLIP", true))
+            m.assertInvalid(getRowConfig("UNKNOWN", true))
         end sub
 
         @it("returns invalid when contentType is invalid")

--- a/source/tests/contentBuilder.spec.bs
+++ b/source/tests/contentBuilder.spec.bs
@@ -1,0 +1,95 @@
+namespace tests
+
+    @suite("ContentBuilder")
+    class ContentBuilderTests extends rooibos.BaseTestSuite
+
+        '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        @describe("getRowConfig LIVE/VOD")
+        '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+        @it("returns correct size for LIVE with row label")
+        sub liveWithLabel()
+            config = getRowConfig("LIVE", true)
+            m.assertEqual(config.itemSize, [320, 180])
+            m.assertEqual(config.rowHeight, 275)
+        end sub
+
+        @it("returns correct size for LIVE without row label")
+        sub liveNoLabel()
+            config = getRowConfig("LIVE", false)
+            m.assertEqual(config.itemSize, [320, 180])
+            m.assertEqual(config.rowHeight, 235)
+        end sub
+
+        @it("returns correct size for VOD with row label")
+        sub vodWithLabel()
+            config = getRowConfig("VOD", true)
+            m.assertEqual(config.itemSize, [320, 180])
+            m.assertEqual(config.rowHeight, 275)
+        end sub
+
+        @it("returns tall row height for LIVE with label")
+        sub liveTallWithLabel()
+            config = getRowConfig("LIVE", true, true)
+            m.assertEqual(config.rowHeight, 295)
+        end sub
+
+        @it("returns tall row height for LIVE without label")
+        sub liveTallNoLabel()
+            config = getRowConfig("LIVE", false, true)
+            m.assertEqual(config.rowHeight, 255)
+        end sub
+
+        '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        @describe("getRowConfig GAME")
+        '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+        @it("returns correct size for GAME with row label")
+        sub gameWithLabel()
+            config = getRowConfig("GAME", true)
+            m.assertEqual(config.itemSize, [188, 250])
+            m.assertEqual(config.rowHeight, 325)
+        end sub
+
+        @it("returns correct size for GAME without row label")
+        sub gameNoLabel()
+            config = getRowConfig("GAME", false)
+            m.assertEqual(config.itemSize, [188, 250])
+            m.assertEqual(config.rowHeight, 305)
+        end sub
+
+        '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        @describe("getRowConfig USER")
+        '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+        @it("returns correct size for USER with row label")
+        sub userWithLabel()
+            config = getRowConfig("USER", true)
+            m.assertEqual(config.itemSize, [150, 150])
+            m.assertEqual(config.rowHeight, 260)
+        end sub
+
+        @it("returns correct size for USER without row label")
+        sub userNoLabel()
+            config = getRowConfig("USER", false)
+            m.assertEqual(config.itemSize, [150, 150])
+            m.assertEqual(config.rowHeight, 240)
+        end sub
+
+        '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        @describe("getRowConfig edge cases")
+        '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+        @it("returns invalid for unknown content type")
+        sub unknownType()
+            m.assertInvalid(getRowConfig("CLIP", true))
+        end sub
+
+        @it("returns invalid when contentType is invalid")
+        sub invalidContentType()
+            m.assertInvalid(getRowConfig(invalid, true))
+        end sub
+
+    end class
+
+end namespace

--- a/source/utils/contentBuilder.brs
+++ b/source/utils/contentBuilder.brs
@@ -7,7 +7,7 @@
 function getRowConfig(contentType, hasRowLabel as boolean, tallRows = false as boolean) as object
     if contentType = invalid then return invalid
 
-    if contentType = "LIVE" or contentType = "VOD"
+    if contentType = "LIVE" or contentType = "VOD" or contentType = "CLIP"
         itemSize = [320, 180]
         if tallRows
             if hasRowLabel

--- a/source/utils/contentBuilder.brs
+++ b/source/utils/contentBuilder.brs
@@ -4,7 +4,9 @@
 ' tallRows: boolean — use taller row heights (Following scene uses larger cards)
 ' Returns: { itemSize: [width, height], rowHeight: integer }
 ' Returns invalid if contentType is unrecognized.
-function getRowConfig(contentType as string, hasRowLabel as boolean, tallRows = false as boolean) as object
+function getRowConfig(contentType, hasRowLabel as boolean, tallRows = false as boolean) as object
+    if contentType = invalid then return invalid
+
     if contentType = "LIVE" or contentType = "VOD"
         itemSize = [320, 180]
         if tallRows

--- a/source/utils/contentBuilder.brs
+++ b/source/utils/contentBuilder.brs
@@ -1,0 +1,45 @@
+' Returns row item size and height config for a given content type.
+' contentType: string — the contentType field from a TwitchContentNode child
+' hasRowLabel: boolean — whether the row has a visible label (affects height)
+' tallRows: boolean — use taller row heights (Following scene uses larger cards)
+' Returns: { itemSize: [width, height], rowHeight: integer }
+' Returns invalid if contentType is unrecognized.
+function getRowConfig(contentType as string, hasRowLabel as boolean, tallRows = false as boolean) as object
+    if contentType = "LIVE" or contentType = "VOD"
+        itemSize = [320, 180]
+        if tallRows
+            if hasRowLabel
+                rowHeight = 295
+            else
+                rowHeight = 255
+            end if
+        else
+            if hasRowLabel
+                rowHeight = 275
+            else
+                rowHeight = 235
+            end if
+        end if
+        return { itemSize: itemSize, rowHeight: rowHeight }
+    end if
+
+    if contentType = "GAME"
+        if hasRowLabel
+            rowHeight = 325
+        else
+            rowHeight = 305
+        end if
+        return { itemSize: [188, 250], rowHeight: rowHeight }
+    end if
+
+    if contentType = "USER"
+        if hasRowLabel
+            rowHeight = 260
+        else
+            rowHeight = 240
+        end if
+        return { itemSize: [150, 150], rowHeight: rowHeight }
+    end if
+
+    return invalid
+end function


### PR DESCRIPTION
## Summary

- Extracts `getRowConfig()` into `source/utils/contentBuilder.brs` — centralizes row item size and height logic for LIVE/VOD, GAME, and USER content types
- Replaces duplicated if/else blocks across 6 scenes: Following, Discover, ChannelPage, GamePage, Categories, LiveChannels
- Search left as-is (fixed-row layout with custom heights that don't follow the shared pattern)
- Net: **-128 lines**, **+36 lines** across 12 files + 1 new utility