### PR TITLE
fix: guard against null stream/video in GetTwitchContent token build

### DIFF
--- a/components/Tasks/GetTwitchContent/GetTwitchContent.brs
+++ b/components/Tasks/GetTwitchContent/GetTwitchContent.brs
@@ -90,8 +90,16 @@ sub main()
 
         usherUrl = ""
         if m.top.contentRequested.contentType = "VOD"
+            if rsp = invalid or rsp.data = invalid or rsp.data.video = invalid or rsp.data.video.playbackAccessToken = invalid
+                m.top.response = invalid
+                return
+            end if
             usherUrl = "https://usher.ttvnw.net/vod/" + rsp.data.video.id + ".m3u8?playlist_include_framerate=true&allow_source=true&player_type=pulsar&player_backend=mediaplayer&reassignments_supported=true&nauth=" + rsp.data.video.playbackAccessToken.value.EncodeUri() + "&nauthsig=" + rsp.data.video.playbackAccessToken.signature
         else if m.top.contentRequested.contentType = "LIVE"
+            if rsp = invalid or rsp.data = invalid or rsp.data.user = invalid or rsp.data.user.stream = invalid or rsp.data.user.stream.playbackAccessToken = invalid
+                m.top.response = invalid
+                return
+            end if
             ' Build base URL with appropriate latency parameters
             usherUrl = "https://usher.ttvnw.net/api/channel/hls/" + rsp.data.user.login + ".m3u8"
             usherUrl += "?allow_source=true"


### PR DESCRIPTION
## Summary

- Adds null guards before building the usher URL in `GetTwitchContent.brs` for both LIVE and VOD content types
- Fixes a `&hec` runtime crash ('Dot' operator on invalid reference) when a LIVE stream's `rsp.data.user.stream` is `null` (streamer is offline) or a VOD's `rsp.data.video` is `null` (VOD unavailable/deleted)

## Root Cause

The Twitch GraphQL playback token query succeeds and returns a valid response even when the target is unavailable — but with `stream: null` (offline streamer) or `video: null` (unavailable VOD). The code previously accessed the deep chain `rsp.data.user.stream.playbackAccessToken.value` without guarding against `stream` being `invalid`, causing a fatal `&hec` crash at line 109 in v2.2.0.

The backtrace confirmed: `usherUrl` had already accumulated `?allow_source=true` (line 108 completed), meaning the crash was on the very next line — the first access of `.stream.`.

## Fix

Added early-return guards immediately before the usher URL is built for each content type:

```brightscript
' LIVE: bail if streamer is offline (stream is null in GraphQL response)
if rsp = invalid or rsp.data = invalid or rsp.data.user = invalid or rsp.data.user.stream = invalid or rsp.data.user.stream.playbackAccessToken = invalid
    m.top.response = invalid
    return
end if

' VOD: bail if video is unavailable/deleted
if rsp = invalid or rsp.data = invalid or rsp.data.video = invalid or rsp.data.video.playbackAccessToken = invalid
    m.top.response = invalid
    return
end if
```

The caller (`VideoPlayer`) already handles `response = invalid` as a playback error, so no further changes are needed.