### PR TITLE
fix: guard top 5 crash sites against invalid references

### DIFF
--- a/components/Modules/VideoItem/VideoItem.brs
+++ b/components/Modules/VideoItem/VideoItem.brs
@@ -32,6 +32,7 @@ sub showcontent()
 end sub
 
 sub GlobalSettings()
+    if m.global = invalid or m.global.constants = invalid then return
     m.itemSubtitle.color = m.global.constants.colors.hinted.grey9
     m.itemThirdTitle.color = m.global.constants.colors.hinted.grey9
 

--- a/components/Scenes/LiveChannels/LiveChannels.brs
+++ b/components/Scenes/LiveChannels/LiveChannels.brs
@@ -135,7 +135,7 @@ end sub
 sub onGetFocus()
     if m.rowlist.focusedChild = invalid
         m.rowlist.setFocus(true)
-    else if m.top.focusedChild.id = "homeRowList"
+    else if m.top.focusedChild <> invalid and m.top.focusedChild.id = "homeRowList"
         m.rowlist.focusedChild.setFocus(true)
         if m.rowlist.rowItemFocused[0] <> invalid
             if m.rowlist.content.getChildCount() > 0

--- a/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
+++ b/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
@@ -76,6 +76,7 @@ function validateOauthToken() as object
     })
     sendResult = req.send()
     if sendResult = invalid
+        m.top.response = { "tokenValid": false }
         m.top.control = "STOP"
         return invalid
     end if

--- a/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
+++ b/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
@@ -74,7 +74,12 @@ function validateOauthToken() as object
         headers: reqHeaders,
         method: "GET"
     })
-    rsp = ParseJSON(req.send())
+    sendResult = req.send()
+    if sendResult = invalid
+        m.top.control = "STOP"
+        return invalid
+    end if
+    rsp = ParseJSON(sendResult)
     if rsp?.status <> invalid
         if rsp.status = 401
             m.top.response = { "tokenValid": false }

--- a/components/heroScene.brs
+++ b/components/heroScene.brs
@@ -167,6 +167,7 @@ sub onMenuSelection()
         end if
         if m.activeNode = invalid
             m.activeNode = buildNode(focusedMenuItem())
+            if m.activeNode = invalid then return
         end if
         m.activeNode.setfocus(true)
     end if
@@ -180,6 +181,7 @@ sub onFollowSelected()
     end if
     if m.activeNode = invalid
         m.activeNode = buildNode("ChannelPage")
+        if m.activeNode = invalid then return
     end if
     m.activeNode.contentRequested = content
     m.activeNode.setfocus(true)
@@ -207,6 +209,7 @@ sub onContentSelected()
     end if
     if m.activeNode = invalid
         m.activeNode = buildNode(id)
+        if m.activeNode = invalid then return
     end if
     m.activeNode.contentRequested = content
     m.activeNode.setfocus(true)

--- a/components/heroScene.brs
+++ b/components/heroScene.brs
@@ -105,6 +105,7 @@ end sub
 function buildNode(name)
     if name <> invalid
         newNode = createObject("roSGNode", name)
+        if newNode = invalid then return invalid
         newNode.id = name
         newNode.translation = [0, 0]
         newNode.observeField("backPressed", "onBackPressed")
@@ -185,6 +186,7 @@ sub onFollowSelected()
 end sub
 
 sub onContentSelected()
+    if m.activeNode = invalid or m.activeNode.contentSelected = invalid then return
     id = invalid
     if m.activeNode.contentSelected.contentType = "STREAMER"
         id = "StreamerChannelPage"


### PR DESCRIPTION
## Summary

Adds null guards to the 5 highest-impact crash sites (excluding #1 which is addressed in PR #61). Together with PR #61, these fixes cover **~95% of all weekly crashes** (~16,300 of ~17,000 crashes/week across ~12,500 devices).

## Crash Data (Apr 9–15, 2026)

| # | Crash Site | Weekly Crashes | Weekly Devices | Root Cause |
|---|---|---|---|---|
| 2 | `VideoItem.brs:35` GlobalSettings | ~3,800 | ~3,300 | `m.global.constants` not yet initialized |
| 3 | `heroScene.brs:189` onContentSelected | ~3,500 | ~2,700 | `m.activeNode.contentSelected` is invalid |
| 4 | `LiveChannels.brs:138` onGetFocus | ~900 | ~770 | `m.top.focusedChild` is invalid |
| 5 | `heroScene.brs:109` buildNode | ~250 | ~200 | `createObject()` returns invalid |
| 6 | `TwitchApiTask.bs:77` validateOauthToken | ~600 | ~430 | `req.send()` returns invalid (network error) |

## Changes

### Commit 1: SceneGraph observer/lifecycle guards
- **`heroScene.brs` onContentSelected**: Guard `m.activeNode` and `.contentSelected` before accessing `.contentType`
- **`heroScene.brs` buildNode**: Guard `createObject()` result before setting fields on it
- **`VideoItem.brs` GlobalSettings**: Guard `m.global.constants` before accessing nested color values
- **`LiveChannels.brs` onGetFocus**: Guard `m.top.focusedChild` before accessing `.id`

### Commit 2: API network failure guard
- **`TwitchApiTask.bs` validateOauthToken**: Guard `req.send()` result before passing to `ParseJSON()` — network errors/timeouts return `invalid`

## Pattern

Every crash is the same class: unguarded dot-operator on a value that is `invalid` at runtime (`&hec` error). The fixes are minimal early-return guards at each crash site.