### PR TITLE
refactor: add API boundary layer for ChannelPage (crash-safe response parsing)

### DIFF
--- a/components/Scenes/ChannelPage/ChannelPage.brs
+++ b/components/Scenes/ChannelPage/ChannelPage.brs
@@ -48,8 +48,9 @@ end sub
 sub setBannerImage()
     bannerGroup = m.top.findNode("banner")
     poster = createObject("roSGNode", "Poster")
-    if m.GetShellTask.response.data.userOrError.bannerImageUrl <> invalid
-        poster.uri = m.GetShellTask.response.data.userOrError.bannerImageUrl
+    rsp = m.GetShellTask.response
+    if rsp?.bannerImageUrl <> invalid
+        poster.uri = rsp.bannerImageUrl
     else
         poster.uri = "pkg:/images/default_banner.png"
     end if
@@ -67,41 +68,27 @@ sub setBannerImage()
 end sub
 
 sub updateChannelInfo()
-    ' m.GetcontentTask.response.data.channel
-    ' id                : 71092938
-    ' __typename        : User
-    ' login             : xqc
-    ' stream            :
-    ' videoShelves      : @{edges=System.Object[]}
-    ' self              : @{follower=; subscriptionBenefit=}
-    ' displayName       : xQc
-    ' hosting           :
-    ' videos            : @{edges=System.Object[]}
-    ' roles             : @{isPartner=True}
-    ' broadcastSettings : @{isMature=False; id=71092938; __typename=BroadcastSettings}
-    ' description       : THE BEST AT ABSOLUTELY EVERYTHING. THE JUICER. LEADER OF THE JUICERS.
-    ' followers         : @{totalCount=11870230}
-    ' profileImageURL   : https://static-cdn.jtvnw.net/jtv_user_pictures/xqc-profile_image-9298dca608632101-70x70.jpeg
-    ' profileViewCount  :
-    m.description.infoText = m.GetcontentTask.response.data.channel.description
-    m.followers.text = numberToText(m.GetcontentTask.response.data.channel.followers.totalCount) + " " + tr("followers")
-    m.avatar.uri = m.GetcontentTask.response.data.channel.profileImageUrl
-    channelContent = buildContentNodeFromShelves(m.GetcontentTask.response.data)
+    rsp = m.GetcontentTask.response
+    if rsp = invalid then return
+    m.description.infoText = rsp.description
+    m.followers.text = numberToText(rsp.followerCount) + " " + tr("followers")
+    if rsp.profileImageUrl <> invalid
+        m.avatar.uri = rsp.profileImageUrl
+    end if
+    channelContent = buildContentNodeFromShelves(rsp)
     updateRowList(channelContent)
-    ' ? "Resp: "; m.GetcontentTask.response
-    ' ? "Resp: "; m.GetcontentTask.response.data
 end sub
 
-function buildContentNodeFromShelves(inputData)
-    shelves = inputData.channel.videoShelves.edges
+function buildContentNodeFromShelves(rsp)
     contentCollection = createObject("RoSGNode", "ContentNode")
-    if inputData.channel.stream <> invalid
+    if rsp.isLive
         row = createObject("RoSGNode", "ContentNode")
         row.title = "Live Stream"
         rowItem = m.top.contentRequested
         row.appendChild(rowItem)
         contentCollection.appendChild(row)
     end if
+    shelves = rsp.videoShelves
     for each shelf in shelves
         row = createObject("RoSGNode", "ContentNode")
         row.title = shelf.node.title

--- a/components/Scenes/StreamerChannelPage/StreamerChannelPage.brs
+++ b/components/Scenes/StreamerChannelPage/StreamerChannelPage.brs
@@ -65,8 +65,9 @@ end sub
 sub setBannerImage()
     bannerGroup = m.top.findNode("banner")
     poster = createObject("roSGNode", "Poster")
-    if m.GetShellTask?.response?.data?.userOrError?.bannerImageUrl <> invalid
-        poster.uri = m.GetShellTask.response.data.userOrError.bannerImageUrl
+    rsp = m.GetShellTask.response
+    if rsp?.bannerImageUrl <> invalid
+        poster.uri = rsp.bannerImageUrl
     else
         poster.uri = "pkg:/images/default_banner.png"
     end if
@@ -84,28 +85,13 @@ sub setBannerImage()
 end sub
 
 sub updateChannelInfo()
-    ' m.GetcontentTask.response.data.channel
-    ' id                : 71092938
-    ' __typename        : User
-    ' login             : xqc
-    ' stream            :
-    ' videoShelves      : @{edges=System.Object[]}
-    ' self              : @{follower=; subscriptionBenefit=}
-    ' displayName       : xQc
-    ' hosting           :
-    ' videos            : @{edges=System.Object[]}
-    ' roles             : @{isPartner=True}
-    ' broadcastSettings : @{isMature=False; id=71092938; __typename=BroadcastSettings}
-    ' description       : THE BEST AT ABSOLUTELY EVERYTHING. THE JUICER. LEADER OF THE JUICERS.
-    ' followers         : @{totalCount=11870230}
-    ' profileImageURL   : https://static-cdn.jtvnw.net/jtv_user_pictures/xqc-profile_image-9298dca608632101-70x70.jpeg
-    ' profileViewCount  :
-    ' m.description.infoText = m.GetcontentTask.response.data.channel.description
-    if m.GetcontentTask?.response?.data?.channel?.followers?.totalcount <> invalid
-        m.followers.text = numberToText(m.GetcontentTask.response.data.channel.followers.totalCount) + " " + tr("followers")
+    rsp = m.GetcontentTask.response
+    if rsp = invalid then return
+    if rsp.followerCount > 0
+        m.followers.text = numberToText(rsp.followerCount) + " " + tr("followers")
     end if
-    if m.GetcontentTask?.response?.data?.channel?.profileimageurl <> invalid
-        m.avatar.uri = m.GetcontentTask.response.data.channel.profileImageUrl
+    if rsp.profileImageUrl <> invalid
+        m.avatar.uri = rsp.profileImageUrl
     end if
 end sub
 

--- a/components/Scenes/StreamerChannelPage/StreamerChannelPage.brs
+++ b/components/Scenes/StreamerChannelPage/StreamerChannelPage.brs
@@ -87,9 +87,7 @@ end sub
 sub updateChannelInfo()
     rsp = m.GetcontentTask.response
     if rsp = invalid then return
-    if rsp.followerCount > 0
-        m.followers.text = numberToText(rsp.followerCount) + " " + tr("followers")
-    end if
+    m.followers.text = numberToText(rsp.followerCount) + " " + tr("followers")
     if rsp.profileImageUrl <> invalid
         m.avatar.uri = rsp.profileImageUrl
     end if

--- a/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
+++ b/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
@@ -191,11 +191,14 @@ function getChannelHomeQuery() as object
             "skipPlayToken": false
         }
     })
-    if rsp <> invalid
-        m.top.response = rsp
-    else
-        m.top.response = { "response": invalid }
-    end if
+    channel = rsp?.data?.channel
+    m.top.response = {
+        description: channel?.description ?? "",
+        followerCount: channel?.followers?.totalCount ?? 0,
+        profileImageUrl: channel?.profileImageUrl,
+        isLive: channel?.stream <> invalid,
+        videoShelves: channel?.videoShelves?.edges ?? []
+    }
     m.top.control = "STOP"
     return invalid
 end function
@@ -343,11 +346,9 @@ function getChannelShell()
             }
         }
     })
-    if rsp <> invalid
-        m.top.response = rsp
-    else
-        m.top.response = { "response": invalid }
-    end if
+    m.top.response = {
+        bannerImageUrl: rsp?.data?.userOrError?.bannerImageUrl
+    }
     m.top.control = "STOP"
     return invalid
 end function

--- a/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
+++ b/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
@@ -191,6 +191,11 @@ function getChannelHomeQuery() as object
             "skipPlayToken": false
         }
     })
+    if rsp = invalid
+        m.top.response = invalid
+        m.top.control = "STOP"
+        return invalid
+    end if
     channel = rsp?.data?.channel
     m.top.response = {
         description: channel?.description ?? "",
@@ -346,6 +351,11 @@ function getChannelShell()
             }
         }
     })
+    if rsp = invalid
+        m.top.response = invalid
+        m.top.control = "STOP"
+        return invalid
+    end if
     m.top.response = {
         bannerImageUrl: rsp?.data?.userOrError?.bannerImageUrl
     }


### PR DESCRIPTION
## Summary

Adds an API boundary layer to `getChannelHomeQuery` and `getChannelShell` in TwitchApiTask — the two most crash-prone API functions (ranked #1 and #2 by fragility analysis).

**Before:** Raw GraphQL blobs passed to callers, who access 4-5 level deep chains (`rsp.data.channel.followers.totalCount`) with zero null guards.

**After:** API functions return validated flat structs with optional chaining + defaults. Callers read one level deep (`rsp.followerCount`). Any `invalid` in the GraphQL response is caught at the boundary, not in the UI layer.

### `getChannelHomeQuery` now returns:
```
{ description, followerCount, profileImageUrl, isLive, videoShelves }
```

### `getChannelShell` now returns:
```
{ bannerImageUrl }
```

Both ChannelPage and StreamerChannelPage callers updated.

## Next steps

This is the first incremental step. Same treatment will be applied to the remaining crash-prone functions (Following, Discover) in follow-up PRs.