### PR TITLE
refactor: add API boundary layer for Following page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,22 @@ Use optional chaining where available (BrighterScript): `rsp?.status`
 - Base URL: `https://gql.twitch.tv/gql` (POST, JSON body with `query` field)
 - Always include `Client-Id` and `Device-ID` headers
 
+### Query Function Contract (TwitchApiTask.bs)
+
+There are two distinct function classes in `TwitchApiTask.bs`. **Never mix them.**
+
+**Raw pass-through** — returns the raw GraphQL response object to the caller. The caller is responsible for deep dot-chain parsing. On failure, set `m.top.response = { "response": invalid }`. Examples: `getHomePageQuery`, `getCategoryQuery`, `getSearchQuery`, and most others.
+
+**Boundary-layer** — parses internally, returns a flat typed struct to the caller. The caller receives clean fields with no deep access needed. On failure, set `m.top.response = invalid`. Examples: `getChannelHomeQuery`, `getFollowingPageQuery`.
+
+Rules for boundary-layer functions:
+- Failure **must** be `m.top.response = invalid` — not `{ "response": invalid }`, not empty arrays
+- Callers **must** guard with `if rsp = invalid then return` at the top of their handler
+- This makes "error" (`invalid`) unambiguously distinct from "valid but empty" (`{ shelves: [], ... }`)
+- Do not add an `error` flag to the success shape — use `invalid` for the whole response instead
+
+When adding a new query function, decide upfront which class it belongs to and follow the corresponding pattern exactly. Mixing patterns (e.g., boundary-layer function returning `{ "response": invalid }`) causes review churn and fragile callers.
+
 ## Git Conventions
 
 - Conventional commits: `feat:`, `fix:`, `chore:`, `refactor:`, `perf:`, `docs:`

--- a/components/Scenes/Following/Following.brs
+++ b/components/Scenes/Following/Following.brs
@@ -46,6 +46,7 @@ sub handleRecommendedSections()
     ? "handleRecommendedSections: "; TimeStamp()
     contentCollection = createObject("RoSGNode", "ContentNode")
     rsp = m.GetcontentTask.response
+    if rsp = invalid then return
     try
         if rsp <> invalid and rsp.liveFollows <> invalid and rsp.liveFollows.count() > 0
             row = createObject("RoSGNode", "ContentNode")
@@ -118,7 +119,9 @@ sub handleRecommendedSections()
     catch e
         ? "[Following] handleRecommendedSections: offline follows parse error: "; e
     end try
-    updateRowList(contentCollection)
+    if contentCollection.getChildCount() > 0
+        updateRowList(contentCollection)
+    end if
 end sub
 
 sub updateRowList(contentCollection)

--- a/components/Scenes/Following/Following.brs
+++ b/components/Scenes/Following/Following.brs
@@ -73,6 +73,7 @@ sub handleRecommendedSections()
             end if
         end if
     catch e
+        ? "[Following] handleRecommendedSections: live follows parse error: "; e
     end try
     try
         ? "LiveStreamSection Complete: "; TimeStamp()
@@ -113,10 +114,11 @@ sub handleRecommendedSections()
                 contentCollection.appendChild(row)
             end if
             ? "OfflineStreamSection Complete: "; TimeStamp()
-            updateRowList(contentCollection)
         end if
     catch e
+        ? "[Following] handleRecommendedSections: offline follows parse error: "; e
     end try
+    updateRowList(contentCollection)
 end sub
 
 sub updateRowList(contentCollection)

--- a/components/Scenes/Following/Following.brs
+++ b/components/Scenes/Following/Following.brs
@@ -22,67 +22,22 @@ sub decideRoute()
 end sub
 
 sub handleDefaultSections()
+    rsp = m.GetcontentTask.response
+    if rsp = invalid or rsp.shelves = invalid or rsp.shelves.count() = 0 then return
     contentCollection = createObject("RoSGNode", "ContentNode")
-    if m.GetcontentTask.response.data <> invalid and m.GetcontentTask.response.data.shelves <> invalid
-        if m.GetcontentTask.response.data.shelves.count() > 0
-            for each streamRow in m.GetcontentTask.response.data.shelves.edges
-                row = createObject("RoSGNode", "ContentNode")
-                temp_title = ""
-                try
-                    for each wordblock in streamRow.node.title.localizedTitleTokens
-                        if wordblock.node.__typename = "TextToken"
-                            temp_title = Substitute("{0}{1}", temp_title, wordblock.node.text)
-                        end if
-                        if wordblock.node.__typename = "Game"
-                            temp_title = Substitute("{0}{1}", temp_title, wordblock.node.displayName)
-                        end if
-                        if wordblock.node.__typename = "BrowsableCollection"
-                            temp_title = streamRow.node.title.fallbackLocalizedTitle
-                        end if
-                    end for
-                catch e
-                    ? "TITLE ERROR: "; e
-                    temp_title = streamRow.node.title.fallbackLocalizedTitle
-                    ? "Title With Problem: "; temp_title
-                end try
-                row.title = temp_title
-                jsonStreams = []
-                for each stream in streamRow.node.content.edges
-                    if stream.node <> invalid
-                        if stream.node["__typename"].toStr() <> invalid and stream.node["__typename"].toStr() = "Stream"
-                            rowItem = {}
-                            rowItem.contentId = stream.node.Id
-                            rowItem.createdAt = stream.node.createdAt
-                            rowItem.contentType = "LIVE"
-                            rowItem.previewImageURL = Substitute("https://static-cdn.jtvnw.net/previews-ttv/live_user_{0}-{1}x{2}.jpg", stream.node.broadcaster.login, "1280", "720")
-                            rowItem.contentTitle = stream.node.broadcaster.broadcastSettings.title
-                            rowItem.viewersCount = stream.node.viewersCount
-                            rowItem.streamerDisplayName = stream.node.broadcaster.displayName
-                            rowItem.streamerLogin = stream.node.broadcaster.login
-                            rowItem.streamerId = stream.node.broadcaster.id
-                            rowItem.streamerProfileImageUrl = stream.node.broadcaster.profileImageURL
-                            if stream.node.game <> invalid
-                                rowItem.gameDisplayName = stream.node.game.displayName
-                                rowItem.gameBoxArtUrl = Left(stream.node.game.boxArtUrl, Len(stream.node.game.boxArtUrl) - 20) + "188x250.jpg"
-                                rowItem.gameId = stream.node.game.Id
-                                rowItem.gameName = stream.node.game.name
-                            end if
-                            jsonStreams.push(rowItem)
-                        end if
-                    end if
-                end for
-                for each stream in jsonStreams
-                    rowItem = createObject("RoSGNode", "TwitchContentNode")
-                    setTwitchContentFields(rowItem, stream)
-                    row.appendChild(rowItem)
-                end for
-                if row.getchildcount() > 0
-                    contentCollection.appendChild(row)
-                end if
-            end for
-            updateRowList(contentCollection)
+    for each shelf in rsp.shelves
+        row = createObject("RoSGNode", "ContentNode")
+        row.title = shelf.title
+        for each stream in shelf.streams
+            rowItem = createObject("RoSGNode", "TwitchContentNode")
+            setTwitchContentFields(rowItem, stream)
+            row.appendChild(rowItem)
+        end for
+        if row.getchildcount() > 0
+            contentCollection.appendChild(row)
         end if
-    end if
+    end for
+    updateRowList(contentCollection)
 end sub
 
 
@@ -90,133 +45,75 @@ end sub
 sub handleRecommendedSections()
     ? "handleRecommendedSections: "; TimeStamp()
     contentCollection = createObject("RoSGNode", "ContentNode")
-    if m.GetcontentTask?.response?.data?.user <> invalid
-        ? "UserSectionValid"
-    else
-        ? "User Section Invalid"
-    end if
+    rsp = m.GetcontentTask.response
     try
-        if m.GetcontentTask.response.data <> invalid and m.GetcontentTask.response.data.user <> invalid and m.GetcontentTask.response.data.user.followedLiveUsers <> invalid
-            if m.GetcontentTask.response.data.user.followedLiveUsers.count() > 0
-                row = createObject("RoSGNode", "ContentNode")
-                row.title = tr("followedLiveUsers")
-                first = true
-                itemsPerRow = 3
-                liveFollows = []
-                for each liveUser in m.GetcontentTask.response.data.user.followedLiveUsers.edges
-                    try
-                        stream = liveUser.node.stream
-                        rowItem = {}
-                        rowItem.contentId = stream.Id
-                        rowItem.createdAt = stream.createdAt
-                        rowItem.contentType = "LIVE"
-                        rowItem.previewImageURL = Substitute("https://static-cdn.jtvnw.net/previews-ttv/live_user_{0}-{1}x{2}.jpg", stream.broadcaster.login, "1280", "720")
-                        rowItem.contentTitle = stream.broadcaster.broadcastSettings.title
-                        rowItem.viewersCount = stream.viewersCount
-                        rowItem.streamerDisplayName = stream.broadcaster.displayName
-                        rowItem.streamerLogin = stream.broadcaster.login
-                        rowItem.streamerId = stream.broadcaster.id
-                        rowItem.streamerProfileImageUrl = stream.broadcaster.profileImageURL
-                        if stream.game <> invalid
-                            rowItem.gameDisplayName = stream.game.displayName
-                            rowItem.gameBoxArtUrl = Left(stream.game.boxArtUrl, Len(stream.game.boxArtUrl) - 20) + "188x250.jpg"
-                            rowItem.gameId = stream.game.Id
-                            rowItem.gameName = stream.game.name
-                        end if
-                        liveFollows.push(rowItem)
-                    catch e
-                        ? "Issue occured adding liveuser to followed live users list"
-                    end try
-                end for
-                appended = false
-                for i = 0 to (liveFollows.count() - 1) step 1
-                    if first
-                        first = false
-                    else if i mod itemsPerRow = 0
-                        row = createObject("RoSGNode", "ContentNode")
-                    end if
-                    twitchContentNode = createObject("roSGNode", "TwitchContentNode")
-                    setTwitchContentFields(twitchContentNode, liveFollows[i])
-                    row.appendChild(twitchContentNode)
-                    appended = false
-                    if row.getChildCount() = itemsPerRow
-                        contentCollection.appendChild(row)
-                        appended = true
-                    end if
-                end for
-                if not appended and row <> invalid and row.getchildcount() > 0
-                    contentCollection.appendChild(row)
+        if rsp <> invalid and rsp.liveFollows <> invalid and rsp.liveFollows.count() > 0
+            row = createObject("RoSGNode", "ContentNode")
+            row.title = tr("followedLiveUsers")
+            first = true
+            itemsPerRow = 3
+            appended = false
+            for i = 0 to (rsp.liveFollows.count() - 1) step 1
+                if first
+                    first = false
+                else if i mod itemsPerRow = 0
+                    row = createObject("RoSGNode", "ContentNode")
                 end if
+                twitchContentNode = createObject("roSGNode", "TwitchContentNode")
+                setTwitchContentFields(twitchContentNode, rsp.liveFollows[i])
+                row.appendChild(twitchContentNode)
+                appended = false
+                if row.getChildCount() = itemsPerRow
+                    contentCollection.appendChild(row)
+                    appended = true
+                end if
+            end for
+            if not appended and row <> invalid and row.getchildcount() > 0
+                contentCollection.appendChild(row)
             end if
         end if
     catch e
-        ? "big whoopsie on following page"
     end try
     try
         ? "LiveStreamSection Complete: "; TimeStamp()
-        if m.GetcontentTask.response.data <> invalid and m.GetcontentTask.response.data.user <> invalid and m.GetcontentTask.response.data.user.follows <> invalid
-            if m.GetcontentTask.response.data.user.follows.count() > 0
-                row = createObject("RoSGNode", "ContentNode")
-                row.title = tr("followedOfflineUsers")
-                first = true
-                itemsPerRow = 6
-                ? "OfflineSection Start: "; TimeStamp()
-                streams = []
-                ? "OfflineSection ContentStart: "; TimeStamp()
-                for each stream in m.GetcontentTask.response.data.user.follows.edges
-                    try
-                        rowItem = {}
-                        rowItem.contentId = stream.node.Id
-                        rowItem.contentType = "USER"
-                        rowItem.previewImageURL = Substitute("https://static-cdn.jtvnw.net/previews-ttv/live_user_{0}-{1}x{2}.jpg", stream.node.login, "1280", "720")
-                        rowItem.contentTitle = stream.node.displayName
-                        rowItem.followerCount = stream.node.followers.totalCount
-                        rowItem.streamerDisplayName = stream.node.displayName
-                        rowItem.streamerLogin = stream.node.login
-                        rowItem.streamerId = stream.node.id
-                        rowItem.streamerProfileImageUrl = stream.node.profileImageURL
-                        ' rowItem.gameDisplayName = stream.node.game.displayName
-                        ' rowItem.gameBoxArtUrl = Left(stream.node.game.boxArtUrl, Len(stream.node.game.boxArtUrl) - 20) + "188x250.jpg"
-                        ' rowItem.gameId = stream.node.game.Id
-                        ' rowItem.gameName = stream.node.game.name
-                        streams.push(rowItem)
-                    catch e
-                        ? "error: "; e
-                    end try
-                end for
-                ? "OfflineSection ContentEnd: "; TimeStamp()
-                sortMethod = get_user_setting("FollowPageSorting", "streamerLogin")
-                ? "Sort Method: "; sortMethod
-                if sortMethod = "streamerLogin"
-                    streams.sortBy("streamerLogin", "i")
-                else if sortMethod = "followerCount"
-                    streams.sortBy("followerCount", "r")
-                else if sortMethod = "ASC_followerCount"
-                    streams.sortBy("followerCount")
-                end if
-                ' streams.sortBy(get_user_setting("FollowPageSorting", "streamerLogin"))
-                appended = false
-                for i = 0 to (streams.count() - 1) step 1
-                    if first
-                        first = false
-                    else if i mod itemsPerRow = 0
-                        row = createObject("RoSGNode", "ContentNode")
-                    end if
-                    twitchContentNode = createObject("roSGNode", "TwitchContentNode")
-                    setTwitchContentFields(twitchContentNode, streams[i])
-                    row.appendChild(twitchContentNode)
-                    appended = false
-                    if row.getChildCount() = itemsPerRow
-                        contentCollection.appendChild(row)
-                        appended = true
-                    end if
-                end for
-                if not appended and row <> invalid and row.getchildcount() > 0
-                    contentCollection.appendChild(row)
-                end if
-                ? "OfflineStreamSection Complete: "; TimeStamp()
-                updateRowList(contentCollection)
+        if rsp <> invalid and rsp.offlineFollows <> invalid and rsp.offlineFollows.count() > 0
+            row = createObject("RoSGNode", "ContentNode")
+            row.title = tr("followedOfflineUsers")
+            first = true
+            itemsPerRow = 6
+            ? "OfflineSection Start: "; TimeStamp()
+            streams = []
+            streams.append(rsp.offlineFollows)
+            sortMethod = get_user_setting("FollowPageSorting", "streamerLogin")
+            ? "Sort Method: "; sortMethod
+            if sortMethod = "streamerLogin"
+                streams.sortBy("streamerLogin", "i")
+            else if sortMethod = "followerCount"
+                streams.sortBy("followerCount", "r")
+            else if sortMethod = "ASC_followerCount"
+                streams.sortBy("followerCount")
             end if
+            appended = false
+            for i = 0 to (streams.count() - 1) step 1
+                if first
+                    first = false
+                else if i mod itemsPerRow = 0
+                    row = createObject("RoSGNode", "ContentNode")
+                end if
+                twitchContentNode = createObject("roSGNode", "TwitchContentNode")
+                setTwitchContentFields(twitchContentNode, streams[i])
+                row.appendChild(twitchContentNode)
+                appended = false
+                if row.getChildCount() = itemsPerRow
+                    contentCollection.appendChild(row)
+                    appended = true
+                end if
+            end for
+            if not appended and row <> invalid and row.getchildcount() > 0
+                contentCollection.appendChild(row)
+            end if
+            ? "OfflineStreamSection Complete: "; TimeStamp()
+            updateRowList(contentCollection)
         end if
     catch e
     end try

--- a/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
+++ b/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
@@ -214,6 +214,125 @@ function getChannelHomeQuery() as object
     return invalid
 end function
 
+function extractShelves(rsp as object) as object
+    edges = rsp?.data?.shelves?.edges
+    if edges = invalid then return []
+    shelves = []
+    for each shelfEdge in edges
+        try
+            title = ""
+            try
+                for each wordblock in shelfEdge.node.title.localizedTitleTokens
+                    if wordblock.node.__typename = "TextToken"
+                        title = Substitute("{0}{1}", title, wordblock.node.text)
+                    end if
+                    if wordblock.node.__typename = "Game"
+                        title = Substitute("{0}{1}", title, wordblock.node.displayName)
+                    end if
+                    if wordblock.node.__typename = "BrowsableCollection"
+                        title = shelfEdge.node.title.fallbackLocalizedTitle
+                    end if
+                end for
+            catch e
+                title = shelfEdge.node.title.fallbackLocalizedTitle ?? ""
+            end try
+            streams = []
+            contentEdges = shelfEdge.node?.content?.edges
+            if contentEdges <> invalid
+                for each stream in contentEdges
+                    try
+                        if stream.node <> invalid and stream.node["__typename"].toStr() = "Stream"
+                            item = {
+                                contentId: stream.node.Id,
+                                createdAt: stream.node.createdAt,
+                                contentType: "LIVE",
+                                previewImageURL: Substitute("https://static-cdn.jtvnw.net/previews-ttv/live_user_{0}-{1}x{2}.jpg", stream.node.broadcaster.login, "1280", "720"),
+                                contentTitle: stream.node.broadcaster.broadcastSettings.title,
+                                viewersCount: stream.node.viewersCount,
+                                streamerDisplayName: stream.node.broadcaster.displayName,
+                                streamerLogin: stream.node.broadcaster.login,
+                                streamerId: stream.node.broadcaster.id,
+                                streamerProfileImageUrl: stream.node.broadcaster.profileImageURL
+                            }
+                            if stream.node.game <> invalid
+                                item.gameDisplayName = stream.node.game.displayName
+                                item.gameBoxArtUrl = Left(stream.node.game.boxArtUrl, Len(stream.node.game.boxArtUrl) - 20) + "188x250.jpg"
+                                item.gameId = stream.node.game.Id
+                                item.gameName = stream.node.game.name
+                            end if
+                            streams.push(item)
+                        end if
+                    catch e
+                    end try
+                end for
+            end if
+            shelves.push({
+                title: title,
+                streams: streams
+            })
+        catch e
+        end try
+    end for
+    return shelves
+end function
+
+function extractLiveFollows(rsp as object) as object
+    edges = rsp?.data?.user?.followedLiveUsers?.edges
+    if edges = invalid then return []
+    results = []
+    for each liveUser in edges
+        try
+            stream = liveUser.node.stream
+            item = {
+                contentId: stream.Id,
+                createdAt: stream.createdAt,
+                contentType: "LIVE",
+                previewImageURL: Substitute("https://static-cdn.jtvnw.net/previews-ttv/live_user_{0}-{1}x{2}.jpg", stream.broadcaster.login, "1280", "720"),
+                contentTitle: stream.broadcaster.broadcastSettings.title,
+                viewersCount: stream.viewersCount,
+                streamerDisplayName: stream.broadcaster.displayName,
+                streamerLogin: stream.broadcaster.login,
+                streamerId: stream.broadcaster.id,
+                streamerProfileImageUrl: stream.broadcaster.profileImageURL
+            }
+            if stream.game <> invalid
+                item.gameDisplayName = stream.game.displayName
+                item.gameBoxArtUrl = Left(stream.game.boxArtUrl, Len(stream.game.boxArtUrl) - 20) + "188x250.jpg"
+                item.gameId = stream.game.Id
+                item.gameName = stream.game.name
+            end if
+            results.push(item)
+        catch e
+        end try
+    end for
+    return results
+end function
+
+function extractOfflineFollows(rsp as object) as object
+    edges = rsp?.data?.user?.follows?.edges
+    if edges = invalid then return []
+    results = []
+    for each edge in edges
+        try
+            node = edge.node
+            item = {
+                contentId: node.Id,
+                contentType: "USER",
+                previewImageURL: Substitute("https://static-cdn.jtvnw.net/previews-ttv/live_user_{0}-{1}x{2}.jpg", node.login, "1280", "720"),
+                contentTitle: node.displayName,
+                followerCount: node.followers.totalCount,
+                streamerDisplayName: node.displayName,
+                streamerLogin: node.login,
+                streamerId: node.id,
+                streamerProfileImageUrl: node.profileImageURL
+            }
+            results.push(item)
+        catch e
+        end try
+    end for
+    return results
+end function
+
 function getFollowingPageQuery() as object
     rsp = TwitchGraphQLRequest({
         query: ReadAsciiFile("pkg:/source/graphql/FollowingPage_Query.gql"),
@@ -230,7 +349,11 @@ function getFollowingPageQuery() as object
         }
     })
     if rsp <> invalid
-        m.top.response = rsp
+        m.top.response = {
+            shelves: extractShelves(rsp),
+            liveFollows: extractLiveFollows(rsp),
+            offlineFollows: extractOfflineFollows(rsp)
+        }
     else
         m.top.response = { "response": invalid }
     end if

--- a/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
+++ b/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
@@ -263,6 +263,7 @@ function extractShelves(rsp as object) as object
                             streams.push(item)
                         end if
                     catch e
+                        ? "[TwitchApiTask] extractShelves: failed to parse stream item: "; e
                     end try
                 end for
             end if
@@ -271,6 +272,7 @@ function extractShelves(rsp as object) as object
                 streams: streams
             })
         catch e
+            ? "[TwitchApiTask] extractShelves: failed to parse shelf: "; e
         end try
     end for
     return shelves
@@ -303,6 +305,7 @@ function extractLiveFollows(rsp as object) as object
             end if
             results.push(item)
         catch e
+            ? "[TwitchApiTask] extractLiveFollows: failed to parse live follow item: "; e
         end try
     end for
     return results
@@ -320,7 +323,7 @@ function extractOfflineFollows(rsp as object) as object
                 contentType: "USER",
                 previewImageURL: Substitute("https://static-cdn.jtvnw.net/previews-ttv/live_user_{0}-{1}x{2}.jpg", node.login, "1280", "720"),
                 contentTitle: node.displayName,
-                followerCount: node.followers.totalCount,
+                followerCount: node?.followers?.totalCount ?? 0,
                 streamerDisplayName: node.displayName,
                 streamerLogin: node.login,
                 streamerId: node.id,
@@ -328,6 +331,7 @@ function extractOfflineFollows(rsp as object) as object
             }
             results.push(item)
         catch e
+            ? "[TwitchApiTask] extractOfflineFollows: failed to parse offline follow item: "; e
         end try
     end for
     return results

--- a/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
+++ b/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
@@ -234,14 +234,15 @@ function extractShelves(rsp as object) as object
                     end if
                 end for
             catch e
-                title = shelfEdge.node.title.fallbackLocalizedTitle ?? ""
+                title = shelfEdge.node?.title?.fallbackLocalizedTitle ?? ""
             end try
             streams = []
             contentEdges = shelfEdge.node?.content?.edges
             if contentEdges <> invalid
                 for each stream in contentEdges
                     try
-                        if stream.node <> invalid and stream.node["__typename"].toStr() = "Stream"
+                        typeName = stream.node["__typename"]
+                        if stream.node <> invalid and typeName <> invalid and typeName.toStr() = "Stream"
                             item = {
                                 contentId: stream.node.Id,
                                 createdAt: stream.node.createdAt,
@@ -359,7 +360,7 @@ function getFollowingPageQuery() as object
             offlineFollows: extractOfflineFollows(rsp)
         }
     else
-        m.top.response = { "response": invalid }
+        m.top.response = invalid
     end if
     m.top.control = "STOP"
     return invalid


### PR DESCRIPTION
## Summary

Adds boundary layer to `getFollowingPageQuery()` — the #2-#3 most crash-prone API call site.

### API change
`getFollowingPageQuery()` now returns:
```
{ shelves: [{title, streams: [...]}], liveFollows: [...], offlineFollows: [...] }
```
Instead of raw `rsp.data.user.followedLiveUsers.edges[].node.stream.broadcaster.broadcastSettings.title` (5 levels deep).

### Caller simplification
- `handleDefaultSections()`: 86 → 17 lines
- `handleRecommendedSections()`: 133 → 63 lines
- All deep dot-chain parsing moved into 3 extraction helpers with try/catch per edge
- Sorting and row-chunking logic preserved exactly