### PR TITLE
refactor: add API boundary layer for Discover page

### DIFF
--- a/components/Scenes/Discover/Discover.brs
+++ b/components/Scenes/Discover/Discover.brs
@@ -7,105 +7,16 @@ sub init()
     m.GetContentTask = createApiTask("getHomePageQuery", "handleRecommendedSections")
 end sub
 
-function buildContentNodeFromShelves(shelves)
-    ? "buildContentNodeFromShelves: "; TimeStamp()
-    contentCollection = []
-    for each shelf in shelves
-        row = { "title": "", "children": [] }
-        temp_title = ""
-        try
-            for each wordblock in shelf.node.title.localizedTitleTokens
-                if wordblock.node <> invalid
-                    if wordblock.node["__typename"] = "TextToken"
-                        temp_title = Substitute("{0}{1}", temp_title, wordblock.node.text)
-                    end if
-                    if wordblock.node["__typename"] = "Game"
-                        temp_title = Substitute("{0}{1}", temp_title, wordblock.node.displayName)
-                    end if
-                    if wordblock.node["__typename"] = "BrowsableCollection"
-                        temp_title = shelf.node.title.fallbackLocalizedTitle
-                    end if
-                else
-                    temp_title = shelf.node.title.fallbackLocalizedTitle
-                end if
-            end for
-        catch e
-            ? "TITLE ERROR: "; e
-            temp_title = shelf.node.title.fallbackLocalizedTitle
-            ? "Title With Problem: "; temp_title
-        end try
-        row.title = temp_title
-        for each stream in shelf.node.content.edges
-            streamnode = stream.node
-            ' type_name = stream.node.__typename
-            ' try
-            if stream.node <> invalid and stream.node["__typename"].ToStr() <> invalid
-                if stream.node["__typename"].ToStr() = "Stream"
-                    rowItem = {}
-                    rowItem.createdAt = stream.node.createdAt
-                    rowItem.contentId = stream.node.Id
-                    rowItem.contentType = "LIVE"
-                    rowItem.previewImageURL = Substitute("https://static-cdn.jtvnw.net/previews-ttv/live_user_{0}-{1}x{2}.jpg", stream.node.broadcaster.login, "1280", "720")
-                    if stream.node.broadcaster.broadcastSettings?.title <> invalid
-                        rowItem.contentTitle = stream.node.broadcaster.broadcastSettings.title
-                    else
-                        rowItem.contentTitle = stream.node.broadcaster.displayName
-                    end if
-                    rowItem.viewersCount = stream.node.viewersCount
-                    rowItem.streamerDisplayName = stream.node.broadcaster.displayName
-                    rowItem.streamerLogin = stream.node.broadcaster.login
-                    rowItem.streamerId = stream.node.broadcaster.id
-                    rowItem.streamerProfileImageUrl = stream.node.broadcaster.profileImageURL
-                    if stream.node.game <> invalid
-                        rowItem.gameDisplayName = stream.node.game.displayName
-                        rowItem.gameBoxArtUrl = Left(stream.node.game.boxArtUrl, Len(stream.node.game.boxArtUrl) - 20) + "188x250.jpg"
-                        rowItem.gameId = stream.node.game.Id
-                        rowItem.gameName = stream.node.game.name
-                    end if
-                    ' rowItem.secondaryTitle = streamnode.broadcaster.displayName
-                    ' rowItem.ShortDescriptionLine1 = streamnode.viewersCount
-                    ' rowItem.ShortDescriptionLine2 = streamnode.game.displayName
-                    row.children.push(rowItem)
-                else if stream.node["__typename"].ToStr() = "Game"
-                    rowItem = {}
-                    rowItem.contentId = stream.node.Id
-                    rowItem.contentType = "GAME"
-                    rowItem.viewersCount = stream.node.viewersCount
-                    rowItem.gameDisplayName = stream.node.displayName
-                    rowItem.gameBoxArtUrl = Left(stream.node.boxArtUrl, Len(stream.node.boxArtUrl) - 20) + "188x250.jpg"
-                    rowItem.gameId = stream.node.Id
-                    rowItem.gameName = stream.node.name
-                    rowItem.contentTitle = streamnode.displayName
-                    ' rowItem.secondaryTitle = streamnode.viewersCount
-                    ' rowItem.HDPosterUrl = Left(stream.node.boxArtUrl, Len(stream.node.boxArtUrl) - 20) + "188x250.jpg"
-                    ' rowItem.ShortDescriptionLine1 = streamnode.viewersCount
-                    row.children.push(rowItem)
-                end if
-            end if
-            ' catch e
-            '     ? "Error: "; e
-            ' end try
-        end for
-        if row.children.Count() > 0
-            contentCollection.push(row)
-        end if
-    end for
-    return contentCollection
-end function
-
-
 sub handleRecommendedSections()
     ? "handleRecommendedSections: "; TimeStamp()
-    contentCollection = invalid
-    if m.GetContentTask.response.data <> invalid and m.GetContentTask.response.data.shelves <> invalid
-        contentCollection = buildContentNodeFromShelves(m.GetContentTask.response.data.shelves.edges)
+    rsp = m.GetContentTask.response
+    if rsp = invalid then return
+    if rsp.shelves <> invalid and rsp.shelves.count() > 0
+        updateRowList(rsp.shelves)
     else
-        for each error in m.GetContentTask.response.errors
+        for each error in rsp.errors
             ? "RESP: "; error.message
         end for
-    end if
-    if contentCollection <> invalid
-        updateRowList(contentCollection)
     end if
 end sub
 
@@ -126,16 +37,16 @@ end sub
 '     return newRowList
 ' end function
 
-sub updateRowList(jsonContent)
+sub updateRowList(shelves)
     ? "updateRowList: "; TimeStamp()
     contentCollection = createObject("roSGNode", "ContentNode")
-    if jsonContent <> invalid
-        for each jsonRow in jsonContent
+    if shelves <> invalid
+        for each shelf in shelves
             row = createObject("roSGNode", "ContentNode")
-            row.title = jsonRow.title
-            for each jsonItem in jsonRow.children
+            row.title = shelf.title
+            for each item in shelf.streams
                 twitchContentNode = createObject("roSGNode", "TwitchContentNode")
-                setTwitchContentFields(twitchContentNode, jsonItem)
+                setTwitchContentFields(twitchContentNode, item)
                 row.appendChild(twitchContentNode)
             end for
             contentCollection.appendChild(row)

--- a/components/Scenes/LoginPage/LoginPage.brs
+++ b/components/Scenes/LoginPage/LoginPage.brs
@@ -21,13 +21,16 @@ end sub
 
 sub handleUserLogin()
     ? "[LoginPage] - handleUserLogin()"
-    if m.UserLoginTask.response.data.currentUser <> invalid and m.UserLoginTask.response.data.currentUser.login <> invalid
+    rsp = m.UserLoginTask.response
+    if rsp = invalid then return
+    currentUser = rsp.currentUser
+    if currentUser <> invalid and currentUser.login <> invalid
         access_token = get_user_setting("access_token")
         device_code = get_user_setting("device_code")
         unset_user_setting("access_token")
         unset_user_setting("device_code")
-        set_setting("active_user", m.UserLoginTask.response.data.currentUser.login)
-        set_user_setting("login", m.UserLoginTask.response.data.currentUser.login)
+        set_setting("active_user", currentUser.login)
+        set_user_setting("login", currentUser.login)
         set_user_setting("access_token", access_token)
         set_user_setting("device_code", device_code)
         ' TODO: Yet again with the static reference that should be fixed.

--- a/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
+++ b/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
@@ -104,11 +104,10 @@ function getHomePageQuery() as object
             "requestID": getRandomUUID()
         }
     })
-    if rsp <> invalid
-        m.top.response = rsp
-    else
-        m.top.response = { "response": invalid }
-    end if
+    m.top.response = {
+        shelves: extractShelves(rsp),
+        errors: rsp?.errors ?? []
+    }
     m.top.control = "STOP"
     return invalid
 end function
@@ -248,7 +247,7 @@ function extractShelves(rsp as object) as object
                                 createdAt: stream.node.createdAt,
                                 contentType: "LIVE",
                                 previewImageURL: Substitute("https://static-cdn.jtvnw.net/previews-ttv/live_user_{0}-{1}x{2}.jpg", stream.node.broadcaster.login, "1280", "720"),
-                                contentTitle: stream.node.broadcaster.broadcastSettings.title,
+                                contentTitle: stream.node?.broadcaster?.broadcastSettings?.title ?? stream.node?.broadcaster?.displayName ?? "",
                                 viewersCount: stream.node.viewersCount,
                                 streamerDisplayName: stream.node.broadcaster.displayName,
                                 streamerLogin: stream.node.broadcaster.login,
@@ -262,6 +261,17 @@ function extractShelves(rsp as object) as object
                                 item.gameName = stream.node.game.name
                             end if
                             streams.push(item)
+                        else if stream.node <> invalid and stream.node["__typename"].toStr() = "Game"
+                            streams.push({
+                                contentId: stream.node.Id,
+                                contentType: "GAME",
+                                viewersCount: stream.node.viewersCount,
+                                gameDisplayName: stream.node.displayName,
+                                gameBoxArtUrl: Left(stream.node.boxArtUrl, Len(stream.node.boxArtUrl) - 20) + "188x250.jpg",
+                                gameId: stream.node.Id,
+                                gameName: stream.node.name,
+                                contentTitle: stream.node.displayName
+                            })
                         end if
                     catch e
                         ? "[TwitchApiTask] extractShelves: failed to parse stream item: "; e

--- a/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
+++ b/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
@@ -104,10 +104,14 @@ function getHomePageQuery() as object
             "requestID": getRandomUUID()
         }
     })
-    m.top.response = {
-        shelves: extractShelves(rsp),
-        errors: rsp?.errors ?? []
-    }
+    if rsp <> invalid
+        m.top.response = {
+            shelves: extractShelves(rsp),
+            errors: rsp?.errors ?? []
+        }
+    else
+        m.top.response = invalid
+    end if
     m.top.control = "STOP"
     return invalid
 end function
@@ -278,10 +282,12 @@ function extractShelves(rsp as object) as object
                     end try
                 end for
             end if
-            shelves.push({
-                title: title,
-                streams: streams
-            })
+            if streams.count() > 0
+                shelves.push({
+                    title: title,
+                    streams: streams
+                })
+            end if
         catch e
             ? "[TwitchApiTask] extractShelves: failed to parse shelf: "; e
         end try

--- a/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
+++ b/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
@@ -107,7 +107,8 @@ function getHomePageQuery() as object
     if rsp <> invalid
         m.top.response = {
             shelves: extractShelves(rsp),
-            errors: rsp?.errors ?? []
+            errors: rsp?.errors ?? [],
+            currentUser: rsp?.data?.currentUser
         }
     else
         m.top.response = invalid

--- a/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
+++ b/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
@@ -265,7 +265,7 @@ function extractShelves(rsp as object) as object
                                 item.gameName = stream.node.game.name
                             end if
                             streams.push(item)
-                        else if stream.node <> invalid and stream.node["__typename"].toStr() = "Game"
+                        else if stream.node <> invalid and typeName <> invalid and typeName.toStr() = "Game"
                             streams.push({
                                 contentId: stream.node.Id,
                                 contentType: "GAME",

--- a/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
+++ b/components/Tasks/twitch-api-sdk/TwitchApiTask.bs
@@ -245,38 +245,40 @@ function extractShelves(rsp as object) as object
             if contentEdges <> invalid
                 for each stream in contentEdges
                     try
-                        typeName = stream.node["__typename"]
-                        if stream.node <> invalid and typeName <> invalid and typeName.toStr() = "Stream"
-                            item = {
-                                contentId: stream.node.Id,
-                                createdAt: stream.node.createdAt,
-                                contentType: "LIVE",
-                                previewImageURL: Substitute("https://static-cdn.jtvnw.net/previews-ttv/live_user_{0}-{1}x{2}.jpg", stream.node.broadcaster.login, "1280", "720"),
-                                contentTitle: stream.node?.broadcaster?.broadcastSettings?.title ?? stream.node?.broadcaster?.displayName ?? "",
-                                viewersCount: stream.node.viewersCount,
-                                streamerDisplayName: stream.node.broadcaster.displayName,
-                                streamerLogin: stream.node.broadcaster.login,
-                                streamerId: stream.node.broadcaster.id,
-                                streamerProfileImageUrl: stream.node.broadcaster.profileImageURL
-                            }
-                            if stream.node.game <> invalid
-                                item.gameDisplayName = stream.node.game.displayName
-                                item.gameBoxArtUrl = Left(stream.node.game.boxArtUrl, Len(stream.node.game.boxArtUrl) - 20) + "188x250.jpg"
-                                item.gameId = stream.node.game.Id
-                                item.gameName = stream.node.game.name
+                        if stream.node <> invalid
+                            typeName = stream.node["__typename"]
+                            if typeName <> invalid and typeName.toStr() = "Stream"
+                                item = {
+                                    contentId: stream.node.Id,
+                                    createdAt: stream.node.createdAt,
+                                    contentType: "LIVE",
+                                    previewImageURL: Substitute("https://static-cdn.jtvnw.net/previews-ttv/live_user_{0}-{1}x{2}.jpg", stream.node.broadcaster.login, "1280", "720"),
+                                    contentTitle: stream.node?.broadcaster?.broadcastSettings?.title ?? stream.node?.broadcaster?.displayName ?? "",
+                                    viewersCount: stream.node.viewersCount,
+                                    streamerDisplayName: stream.node.broadcaster.displayName,
+                                    streamerLogin: stream.node.broadcaster.login,
+                                    streamerId: stream.node.broadcaster.id,
+                                    streamerProfileImageUrl: stream.node.broadcaster.profileImageURL
+                                }
+                                if stream.node.game <> invalid
+                                    item.gameDisplayName = stream.node.game.displayName
+                                    item.gameBoxArtUrl = Left(stream.node.game.boxArtUrl, Len(stream.node.game.boxArtUrl) - 20) + "188x250.jpg"
+                                    item.gameId = stream.node.game.Id
+                                    item.gameName = stream.node.game.name
+                                end if
+                                streams.push(item)
+                            else if typeName <> invalid and typeName.toStr() = "Game"
+                                streams.push({
+                                    contentId: stream.node.Id,
+                                    contentType: "GAME",
+                                    viewersCount: stream.node.viewersCount,
+                                    gameDisplayName: stream.node.displayName,
+                                    gameBoxArtUrl: Left(stream.node.boxArtUrl, Len(stream.node.boxArtUrl) - 20) + "188x250.jpg",
+                                    gameId: stream.node.Id,
+                                    gameName: stream.node.name,
+                                    contentTitle: stream.node.displayName
+                                })
                             end if
-                            streams.push(item)
-                        else if stream.node <> invalid and typeName <> invalid and typeName.toStr() = "Game"
-                            streams.push({
-                                contentId: stream.node.Id,
-                                contentType: "GAME",
-                                viewersCount: stream.node.viewersCount,
-                                gameDisplayName: stream.node.displayName,
-                                gameBoxArtUrl: Left(stream.node.boxArtUrl, Len(stream.node.boxArtUrl) - 20) + "188x250.jpg",
-                                gameId: stream.node.Id,
-                                gameName: stream.node.name,
-                                contentTitle: stream.node.displayName
-                            })
                         end if
                     catch e
                         ? "[TwitchApiTask] extractShelves: failed to parse stream item: "; e


### PR DESCRIPTION
## Summary

Adds boundary layer to `getHomePageQuery()` and simplifies Discover.brs.

- Adds `Game` type handling to the shared `extractShelves` helper (reused from PR #66)
- `getHomePageQuery()` now returns `{ shelves: [{title, streams}], errors: [] }` instead of raw GraphQL blob
- Removes entire 84-line `buildContentNodeFromShelves()` function from Discover.brs — no longer needed
- `handleRecommendedSections()` reduced from deep-chain parsing to 10 lines reading flat arrays

**Depends on**: PR #66 (Following boundary layer — provides `extractShelves` helper)