### PR TITLE
feat: add PostHog analytics integration

### DIFF
--- a/components/Scenes/VideoPlayer/VideoPlayer.brs
+++ b/components/Scenes/VideoPlayer/VideoPlayer.brs
@@ -40,6 +40,12 @@ sub onResponse()
             end if
         end if
 
+        trackEvent("video_load_error", {
+            error_code: m.PlayVideo.response.errorCode,
+            error_message: errorMessage,
+            streamer_login: m.top.contentRequested?.streamerLogin,
+            content_type: m.top.contentRequested?.contentType
+        })
         showErrorDialog(errorTitle, errorMessage)
         return
     end if
@@ -286,6 +292,16 @@ sub playContent()
     m.stallSeconds = 0
     m.reconnectAttempts = 0
 
+    if m.top.contentRequested <> invalid
+        trackEvent("stream_started", {
+            content_type: m.top.contentRequested.contentType,
+            streamer_login: m.top.contentRequested.streamerLogin,
+            content_id: m.top.contentRequested.contentId
+        })
+        m.playbackStartTime = CreateObject("roTimeSpan")
+        m.playbackStartTime.Mark()
+    end if
+
     ' Clean up existing video node and its observers
     if m.video <> invalid
         m.video.unobserveField("toggleChat")
@@ -487,6 +503,18 @@ sub exitPlayer()
     ' reconnects we set allowBreak=false before calling exitPlayer().
     if m.allowBreak
         m.isExiting = true
+    end if
+
+    if m.allowBreak and m.top.contentRequested <> invalid
+        exitProps = {
+            content_type: m.top.contentRequested.contentType,
+            streamer_login: m.top.contentRequested.streamerLogin,
+            content_id: m.top.contentRequested.contentId
+        }
+        if m.playbackStartTime <> invalid
+            exitProps.duration_seconds = Int(m.playbackStartTime.TotalMilliseconds() / 1000)
+        end if
+        trackEvent("stream_ended", exitProps)
     end if
 
     ' Stop watchdog/reconnect timers and clean up any in-flight reconnect task
@@ -706,6 +734,14 @@ sub handleStreamError()
 
     ' Get error classification for user-friendly messages
     errorType = m.errorHandler.callFunc("classifyError", errorCode, errorMessage)
+
+    trackEvent("video_error", {
+        error_code: errorCode,
+        error_message: errorMessage,
+        error_type: errorType,
+        streamer_login: m.top.contentRequested?.streamerLogin,
+        content_type: m.top.contentRequested?.contentType
+    })
 
     recovery = m.errorHandler.callFunc("handleVideoError", errorCode, errorMessage, m.video, m.top.contentRequested)
 

--- a/components/Scenes/VideoPlayer/VideoPlayer.brs
+++ b/components/Scenes/VideoPlayer/VideoPlayer.brs
@@ -292,7 +292,9 @@ sub playContent()
     m.stallSeconds = 0
     m.reconnectAttempts = 0
 
-    if m.top.contentRequested <> invalid
+    ' Only track stream_started and reset the timer on user-initiated plays.
+    ' Internal reconnects (m.allowBreak = false) must not fire this event again.
+    if m.allowBreak and m.top.contentRequested <> invalid
         trackEvent("stream_started", {
             content_type: m.top.contentRequested.contentType,
             streamer_login: m.top.contentRequested.streamerLogin,

--- a/components/Scenes/VideoPlayer/VideoPlayer.xml
+++ b/components/Scenes/VideoPlayer/VideoPlayer.xml
@@ -18,6 +18,7 @@
     <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/taskFactory.brs" />
+    <script type="text/brightscript" uri="pkg:/source/utils/analytics.brs" />
     <children>
         <Chat
             id="chat"

--- a/components/Tasks/Analytics/AnalyticsTask.bs
+++ b/components/Tasks/Analytics/AnalyticsTask.bs
@@ -10,9 +10,8 @@
 ' Respects the "analytics.enabled" registry setting (opt-out, default true).
 ' When disabled, events are silently dropped.
 
-const POSTHOG_CAPTURE_URL = "https://app.posthog.com/capture/"
-' Replace with your PostHog project API key.
-const POSTHOG_API_KEY = "phc_REPLACE_WITH_YOUR_KEY"
+const POSTHOG_CAPTURE_URL = "https://us.i.posthog.com/capture/"
+const POSTHOG_API_KEY = "phc_xfHnhpGgpwjwRCPGDYUeoNGLaazv8uZLu4npYa3huN58"
 
 sub init()
     m.top.functionName = "analyticsLoop"
@@ -50,6 +49,7 @@ sub sendCapture(data as object)
     if props = invalid then props = {}
 
     props.append(getGlobalProps())
+    props["distinct_id"] = getDistinctId()
 
     payload = {
         api_key: POSTHOG_API_KEY,
@@ -71,6 +71,7 @@ sub sendIdentify(data as object)
         event: "$identify",
         distinct_id: getDistinctId(),
         properties: {
+            "distinct_id": getDistinctId(),
             "$set": setProps
         }
     }

--- a/components/Tasks/Analytics/AnalyticsTask.bs
+++ b/components/Tasks/Analytics/AnalyticsTask.bs
@@ -1,0 +1,118 @@
+' PostHog analytics background task.
+'
+' Runs a persistent wait() loop observing two fields on itself:
+'   - capture: fires trackEvent() → POST /capture/ (standard event)
+'   - identify: fires sendIdentify() → POST /capture/ ($identify event with $set)
+'
+' Global props (app_version, is_dev, is_logged_in) are injected automatically
+' on every outbound event so call-sites never need to include them.
+'
+' Respects the "analytics.enabled" registry setting (opt-out, default true).
+' When disabled, events are silently dropped.
+
+const POSTHOG_CAPTURE_URL = "https://app.posthog.com/capture/"
+' Replace with your PostHog project API key.
+const POSTHOG_API_KEY = "phc_REPLACE_WITH_YOUR_KEY"
+
+sub init()
+    m.top.functionName = "analyticsLoop"
+end sub
+
+sub analyticsLoop()
+    m.port = CreateObject("roMessagePort")
+    m.deviceInfo = CreateObject("roDeviceInfo")
+
+    m.top.observeField("capture", m.port)
+    m.top.observeField("identify", m.port)
+
+    while true
+        msg = wait(0, m.port)
+        if type(msg) <> "roSGNodeEvent" then continue while
+
+        if not isAnalyticsEnabled() then continue while
+
+        field = msg.getField()
+        data = msg.getData()
+        if data = invalid then continue while
+
+        if field = "capture"
+            sendCapture(data)
+        else if field = "identify"
+            sendIdentify(data)
+        end if
+    end while
+end sub
+
+' Sends a standard PostHog event with global props auto-injected.
+sub sendCapture(data as object)
+    event = data.event
+    props = data.props
+    if props = invalid then props = {}
+
+    props.append(getGlobalProps())
+
+    payload = {
+        api_key: POSTHOG_API_KEY,
+        event: event,
+        distinct_id: getDistinctId(),
+        properties: props
+    }
+
+    postToPostHog(payload)
+end sub
+
+' Sends a PostHog $identify event with a $set payload.
+sub sendIdentify(data as object)
+    setProps = data.set
+    if setProps = invalid then setProps = {}
+
+    payload = {
+        api_key: POSTHOG_API_KEY,
+        event: "$identify",
+        distinct_id: getDistinctId(),
+        properties: {
+            "$set": setProps
+        }
+    }
+
+    postToPostHog(payload)
+end sub
+
+' Returns props injected into every capture event automatically.
+function getGlobalProps() as object
+    isLoggedIn = get_setting("active_user", "$default$") <> "$default$" and get_user_setting("access_token") <> invalid
+    return {
+        app_version: m.global.appInfo.Version.Version,
+        is_dev: m.global.appInfo.IsDev,
+        is_logged_in: isLoggedIn
+    }
+end function
+
+' Returns the anonymous distinct_id for this device+channel pair.
+' roDeviceInfo.GetChannelClientId() is Roku-assigned, anonymous, per-channel.
+function getDistinctId() as string
+    if m.distinctId = invalid
+        m.distinctId = m.deviceInfo.GetChannelClientId()
+    end if
+    return m.distinctId
+end function
+
+' Fire-and-forget HTTPS POST to PostHog capture endpoint.
+sub postToPostHog(payload as object)
+    transfer = CreateObject("roUrlTransfer")
+    transfer.SetUrl(POSTHOG_CAPTURE_URL)
+    transfer.SetRequest("POST")
+    transfer.AddHeader("Content-Type", "application/json")
+    transfer.SetCertificatesFile("common:/certs/ca-bundle.crt")
+    transfer.InitClientCertificates()
+    transfer.AsyncPostFromString(FormatJson(payload))
+    ' No response handling — fire and forget.
+    ' The roUrlTransfer object stays alive until this scope exits (sub returns),
+    ' which is long enough for the async send to be queued by the OS.
+end sub
+
+' Returns true if analytics is enabled (opt-out: default true).
+function isAnalyticsEnabled() as boolean
+    setting = get_user_setting("analytics.enabled", "true")
+    return setting <> "false"
+end function

--- a/components/Tasks/Analytics/AnalyticsTask.bs
+++ b/components/Tasks/Analytics/AnalyticsTask.bs
@@ -21,6 +21,12 @@ sub analyticsLoop()
     m.port = CreateObject("roMessagePort")
     m.deviceInfo = CreateObject("roDeviceInfo")
 
+    ' Read once at startup. Change takes effect on next app launch.
+    m.enabled = get_user_setting("analytics.enabled", "true") <> "false"
+
+    ' Per-event rate limit state: tracks last send time per event name.
+    m.rateLimits = {}
+
     m.top.observeField("capture", m.port)
     m.top.observeField("identify", m.port)
 
@@ -28,7 +34,7 @@ sub analyticsLoop()
         msg = wait(0, m.port)
         if type(msg) <> "roSGNodeEvent" then continue while
 
-        if not isAnalyticsEnabled() then continue while
+        if not m.enabled then continue while
 
         field = msg.getField()
         data = msg.getData()
@@ -43,8 +49,11 @@ sub analyticsLoop()
 end sub
 
 ' Sends a standard PostHog event with global props auto-injected.
+' Drops the event silently if the same event name was sent within the last 10 seconds.
 sub sendCapture(data as object)
     event = data.event
+    if isRateLimited(event) then return
+
     props = data.props
     if props = invalid then props = {}
 
@@ -114,8 +123,15 @@ sub postToPostHog(payload as object)
     transfer.PostFromString(FormatJson(payload))
 end sub
 
-' Returns true if analytics is enabled (opt-out: default true).
-function isAnalyticsEnabled() as boolean
-    setting = get_user_setting("analytics.enabled", "true")
-    return setting <> "false"
+' Returns true if this event name was already sent within the last 10 seconds.
+' Prevents burst duplicates (e.g. concurrent GraphQL failures all firing api_error).
+function isRateLimited(event as string) as boolean
+    now = CreateObject("roTimeSpan")
+    now.Mark()
+    if m.rateLimits.DoesExist(event)
+        elapsed = m.rateLimits[event].TotalSeconds()
+        if elapsed < 10 then return true
+    end if
+    m.rateLimits[event] = now
+    return false
 end function

--- a/components/Tasks/Analytics/AnalyticsTask.bs
+++ b/components/Tasks/Analytics/AnalyticsTask.bs
@@ -48,14 +48,17 @@ sub sendCapture(data as object)
     props = data.props
     if props = invalid then props = {}
 
-    props.append(getGlobalProps())
-    props["distinct_id"] = getDistinctId()
+    ' Build a new assocarray to avoid mutating the caller's object.
+    mergedProps = {}
+    mergedProps.append(props)
+    mergedProps.append(getGlobalProps())
+    mergedProps["distinct_id"] = getDistinctId()
 
     payload = {
         api_key: POSTHOG_API_KEY,
         event: event,
         distinct_id: getDistinctId(),
-        properties: props
+        properties: mergedProps
     }
 
     postToPostHog(payload)
@@ -98,7 +101,9 @@ function getDistinctId() as string
     return m.distinctId
 end function
 
-' Fire-and-forget HTTPS POST to PostHog capture endpoint.
+' Synchronous HTTPS POST to PostHog capture endpoint.
+' We are already in a background Task thread so blocking is safe.
+' Synchronous avoids the GC risk of async transfers without a retained port.
 sub postToPostHog(payload as object)
     transfer = CreateObject("roUrlTransfer")
     transfer.SetUrl(POSTHOG_CAPTURE_URL)
@@ -106,10 +111,7 @@ sub postToPostHog(payload as object)
     transfer.AddHeader("Content-Type", "application/json")
     transfer.SetCertificatesFile("common:/certs/ca-bundle.crt")
     transfer.InitClientCertificates()
-    transfer.AsyncPostFromString(FormatJson(payload))
-    ' No response handling — fire and forget.
-    ' The roUrlTransfer object stays alive until this scope exits (sub returns),
-    ' which is long enough for the async send to be queued by the OS.
+    transfer.PostFromString(FormatJson(payload))
 end sub
 
 ' Returns true if analytics is enabled (opt-out: default true).

--- a/components/Tasks/Analytics/AnalyticsTask.xml
+++ b/components/Tasks/Analytics/AnalyticsTask.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component name="AnalyticsTask" extends="Task">
+    <interface>
+        <!-- Set to an assocarray with keys: event (string), props (assocarray) -->
+        <field id="capture" type="assocarray" alwaysNotify="true" />
+        <!-- Set to an assocarray with keys: set (assocarray) for $identify -->
+        <field id="identify" type="assocarray" alwaysNotify="true" />
+    </interface>
+    <script type="text/brightscript" uri="AnalyticsTask.bs" />
+    <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
+    <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
+</component>

--- a/components/Tasks/GetTwitchContent/GetTwitchContent.xml
+++ b/components/Tasks/GetTwitchContent/GetTwitchContent.xml
@@ -13,4 +13,5 @@
     <script type="text/brightscript" uri="pkg:/source/utils/http.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
+    <script type="text/brightscript" uri="pkg:/source/utils/analytics.brs" />
 </component>

--- a/components/Tasks/twitch-api-sdk/TwitchApiTask.xml
+++ b/components/Tasks/twitch-api-sdk/TwitchApiTask.xml
@@ -20,4 +20,5 @@
     <script type="text/brightscript" uri="pkg:/source/utils/http.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
+    <script type="text/brightscript" uri="pkg:/source/utils/analytics.brs" />
 </component>

--- a/components/Tasks/twitch-api-sdk/shared.bs
+++ b/components/Tasks/twitch-api-sdk/shared.bs
@@ -42,6 +42,7 @@ function TwitchGraphQLRequest(data)
         rsp = ParseJSON(rspData)
         return rsp
     else
+        trackEvent("api_error", { api: "graphql", reason: "network_failure" })
         return invalid
     end if
 end function

--- a/components/heroScene.brs
+++ b/components/heroScene.brs
@@ -36,9 +36,11 @@ sub sendAppOpenedEvents()
     deviceModel = deviceInfo.GetModel()
     priorCrashReason = m.global.priorExitReason ' set by main.brs before scene creation
 
+    rokuOsVersion = osVersion.major.toStr() + "." + osVersion.minor.toStr() + "." + osVersion.revision.toStr()
+
     appOpenProps = {
         device_model: deviceModel,
-        roku_os_version: osVersion.major + "." + osVersion.minor + "." + osVersion.revision
+        roku_os_version: rokuOsVersion
     }
     if priorCrashReason <> invalid and priorCrashReason <> ""
         appOpenProps.prior_exit_reason = priorCrashReason
@@ -50,7 +52,7 @@ sub sendAppOpenedEvents()
     analyticsIdentify({
         app_version: m.global.appInfo.Version.Version,
         device_model: deviceModel,
-        roku_os_version: osVersion.major + "." + osVersion.minor + "." + osVersion.revision,
+        roku_os_version: rokuOsVersion,
         is_dev: m.global.appInfo.IsDev,
         is_logged_in: isLoggedIn
     })

--- a/components/heroScene.brs
+++ b/components/heroScene.brs
@@ -163,7 +163,10 @@ end sub
 
 sub onMenuSelection()
     ' refreshFollowBar()
-    trackEvent("tab_visited", { tab: focusedMenuItem() })
+    menuItem = focusedMenuItem()
+    if menuItem <> ""
+        trackEvent("tab_visited", { tab: menuItem })
+    end if
     ' If user is already logged in, show them their user page
     if focusedMenuItem() = "LoginPage" and get_setting("active_user", "$default$") <> "$default$"
         content = createObject("roSGNode", "TwitchContentNode")

--- a/components/heroScene.brs
+++ b/components/heroScene.brs
@@ -25,7 +25,35 @@ sub init()
     end if
     m.footprints = []
 
+    sendAppOpenedEvents()
+end sub
 
+' Fires app_opened event and $identify on every launch.
+' Reads prior crash reason stored by main.brs before the scene was created.
+sub sendAppOpenedEvents()
+    deviceInfo = CreateObject("roDeviceInfo")
+    osVersion = deviceInfo.GetOSVersion()
+    deviceModel = deviceInfo.GetModel()
+    priorCrashReason = m.global.priorExitReason ' set by main.brs before scene creation
+
+    appOpenProps = {
+        device_model: deviceModel,
+        roku_os_version: osVersion.major + "." + osVersion.minor + "." + osVersion.revision
+    }
+    if priorCrashReason <> invalid and priorCrashReason <> ""
+        appOpenProps.prior_exit_reason = priorCrashReason
+    end if
+
+    trackEvent("app_opened", appOpenProps)
+
+    isLoggedIn = get_setting("active_user", "$default$") <> "$default$" and get_user_setting("access_token") <> invalid
+    analyticsIdentify({
+        app_version: m.global.appInfo.Version.Version,
+        device_model: deviceModel,
+        roku_os_version: osVersion.major + "." + osVersion.minor + "." + osVersion.revision,
+        is_dev: m.global.appInfo.IsDev,
+        is_logged_in: isLoggedIn
+    })
 end sub
 
 sub cleanUserData()
@@ -133,6 +161,7 @@ end sub
 
 sub onMenuSelection()
     ' refreshFollowBar()
+    trackEvent("tab_visited", { tab: focusedMenuItem() })
     ' If user is already logged in, show them their user page
     if focusedMenuItem() = "LoginPage" and get_setting("active_user", "$default$") <> "$default$"
         content = createObject("roSGNode", "TwitchContentNode")

--- a/components/heroScene.xml
+++ b/components/heroScene.xml
@@ -24,4 +24,5 @@
   <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/taskFactory.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/analytics.brs" />
 </component>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -187,7 +187,7 @@
     },
     {
         "title": "Anonymous Analytics",
-        "description": "Share anonymous usage data to help improve Stitch. No personal information is collected. Disable to opt out.",
+        "description": "Share anonymous usage data to help improve Stitch. No personal information is collected. Changes take effect on next app start.",
         "settingName": "analytics.enabled",
         "type": "bool",
         "default": "true"

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -184,5 +184,12 @@
         "settingName": "FollowBarOption",
         "type": "bool",
         "default": "true"
+    },
+    {
+        "title": "Anonymous Analytics",
+        "description": "Share anonymous usage data to help improve Stitch. No personal information is collected. Disable to opt out.",
+        "settingName": "analytics.enabled",
+        "type": "bool",
+        "default": "true"
     }
 ]

--- a/source/constants.brs
+++ b/source/constants.brs
@@ -346,4 +346,9 @@ sub setConstants()
             }
         }
     })
+
+    ' Start the background analytics task and expose it globally.
+    analyticsTask = CreateObject("roSGNode", "AnalyticsTask")
+    analyticsTask.control = "RUN"
+    m.global.addFields({ analyticsTask: analyticsTask })
 end sub

--- a/source/main.brs
+++ b/source/main.brs
@@ -41,6 +41,14 @@ sub Main(input as dynamic)
     m.global = screen.getGlobalNode()
     setConstants() ' Assuming this sets necessary global constants
 
+    ' Capture prior exit/crash reason before the scene starts so heroScene can
+    ' include it in the app_opened analytics event.
+    priorExitReason = ""
+    if input <> invalid and input.lastExitOrTerminationReason <> invalid
+        priorExitReason = input.lastExitOrTerminationReason.toStr()
+    end if
+    m.global.addFields({ priorExitReason: priorExitReason })
+
     ' Set the message port for screen
     screen.setMessagePort(m.port)
 

--- a/source/utils/analytics.brs
+++ b/source/utils/analytics.brs
@@ -1,0 +1,29 @@
+' Analytics helpers — thin wrappers over the AnalyticsTask global node.
+'
+' Usage (from any component that includes this script):
+'
+'   trackEvent("tab_visited", { tab: "Discover" })
+'   analyticsIdentify({ app_version: "2.3.0", device_model: "4640X", ... })
+'
+' Both functions are safe to call before the task is initialized — events are
+' silently dropped if m.global.analyticsTask is invalid.
+
+' Sends a named event with optional properties.
+' Global props (app_version, is_dev, is_logged_in) are injected automatically
+' by AnalyticsTask — no need to include them here.
+sub trackEvent(event as string, props = {} as object)
+    if m.global.analyticsTask = invalid then return
+    m.global.analyticsTask.capture = {
+        event: event,
+        props: props
+    }
+end sub
+
+' Sends a PostHog $identify event to update person properties.
+' Use on app open to set durable device/app attributes.
+sub analyticsIdentify(setProps as object)
+    if m.global.analyticsTask = invalid then return
+    m.global.analyticsTask.identify = {
+        set: setProps
+    }
+end sub


### PR DESCRIPTION
## Summary

Adds a lightweight, privacy-respecting PostHog analytics integration built in native BrightScript — no SDK, no external dependencies, modeled after Playlet's Sentry telemetry approach.

## What's tracked

**Usage analytics**
- `app_opened` — every launch, with `prior_exit_reason` when the previous session crashed (`EXIT_BRIGHTSCRIPT_CRASH`, `EXIT_OUT_OF_MEMORY`, etc.)
- `tab_visited` — every MenuBar tab switch (Following, Discover, LiveChannels, Categories)
- `stream_started` — content type (LIVE/VOD/CLIP), streamer login, content ID
- `stream_ended` — same fields + `duration_seconds`

**Errors**
- `video_load_error` — manifest errors (restricted, expired, missing)
- `video_error` — player-level errors with error code, message, and classification
- `api_error` — GraphQL network failures

**Global props on every event** (injected automatically by `AnalyticsTask`): `app_version`, `is_dev`, `is_logged_in`

**`$identify` on launch**: `app_version`, `device_model`, `roku_os_version`, `is_dev`, `is_logged_in`

## Architecture

- `components/Tasks/Analytics/AnalyticsTask.bs` — background Task node running a persistent `wait()` loop; observes `capture` and `identify` fields; fires-and-forgets HTTPS POSTs to PostHog
- `source/utils/analytics.brs` — thin `trackEvent()` / `analyticsIdentify()` helpers, safe to call from any component
- Opt-out toggle added to Settings (default: **on**) — user can disable in Settings → "Anonymous Analytics"

## Before shipping

Replace `phc_REPLACE_WITH_YOUR_KEY` in `AnalyticsTask.bs` with your actual PostHog project API key.

## Privacy

Only anonymous data is collected. `distinct_id` is Roku's `GetChannelClientId()` — a device-scoped anonymous identifier with no link to Twitch account or personal information. No PII is sent.