### PR TITLE
chore: rename and resize channel artwork to consistent naming convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ node_modules
 .env.local
 .env.*.local
 
+# Dev tool
+opencode.json
+
 # Roku device specific configs (credentials, IP addresses)
 bsconfig.dev.json
 bsconfig.local.json


### PR DESCRIPTION
## Summary

- Rename channel icon images to a consistent `channel-poster_{resolution}.png` convention
- Resize `channel-poster_sd.png` to the correct Roku-specified 214×144 (was incorrectly 290×218)
- Declare the FHD icon (`mm_icon_focus_fhd`) in the manifest, pointing to the existing 540×405 asset
- Delete `540x405_beta.png` (duplicate of the FHD poster)

## Asset changes

| Old name | New name | Dimensions |
|---|---|---|
| `channel-icon_HD.png` | `channel-poster_hd.png` | 290×218 |
| `540x405.png` | `channel-poster_fhd.png` | 540×405 |
| `channel-poster_sd.png` | `channel-poster_sd.png` *(same)* | **214×144** (resized) |
| `540x405_beta.png` | *(deleted)* | — |

## Manifest changes

- `mm_icon_focus_hd` → `channel-poster_hd.png`
- `mm_icon_focus_sd` → `channel-poster_sd.png`
- Added `mm_icon_focus_fhd` → `channel-poster_fhd.png`
- Lowercased resolution suffixes on `splash_screen_*` keys for consistency