### PR TITLE
fix(videoplayer): stop ChatJob on back press regardless of chat visibility

### DIFF
--- a/components/Scenes/VideoPlayer/VideoPlayer.brs
+++ b/components/Scenes/VideoPlayer/VideoPlayer.brs
@@ -304,6 +304,11 @@ sub exitPlayer()
     ' reconnects we set allowBreak=false before calling exitPlayer().
     if m.allowBreak
         m.isExiting = true
+        ' Stop chat immediately so the IRC connection and ChatJob task are
+        ' released before the scene tears down, regardless of chat visibility.
+        if m.chatWindow <> invalid
+            m.chatWindow.callFunc("stopJobs")
+        end if
     end if
 
     if m.allowBreak and m.top.contentRequested <> invalid
@@ -369,9 +374,6 @@ end sub
 function onKeyEvent(key, press) as boolean
     if press
         if key = "back"
-            if m.chatWindow <> invalid and m.chatWindow.visible = true
-                m.chatWindow.callFunc("stopJobs") ' Stop chat jobs if chat is open
-            end if
             m.allowBreak = true ' Ensure exitPlayer signals upwards
             exitPlayer()
             return true
@@ -921,10 +923,6 @@ end sub
 
 sub onVideoBack()
     ' Called when CustomVideo's back field is true
-    ' ? "[VideoPlayer] Back key propagated from CustomVideo"
-    if m.chatWindow <> invalid and m.chatWindow.visible = true
-        m.chatWindow.callFunc("stopJobs")
-    end if
     m.allowBreak = true
     exitPlayer()
 end sub


### PR DESCRIPTION
## Summary

- ChatJob (IRC connection) was never stopped when the user pressed Back while chat was invisible (disabled in settings)
- `stopJobs()` was previously guarded by `m.chatWindow.visible = true` in `onKeyEvent` and `onVideoBack`, so a hidden-but-running ChatJob leaked its task slot and network connection until the scene was garbage collected
- Moved `stopJobs()` into `exitPlayer()` under the `m.allowBreak` guard, so it fires unconditionally on every real user exit regardless of chat visibility
- Removed the now-redundant (and visibility-gated) `stopJobs` calls from `onKeyEvent` and `onVideoBack` — both paths flow through `exitPlayer()` anyway

## Files changed

- `components/Scenes/VideoPlayer/VideoPlayer.brs`