### PR TITLE
feat(browse): add broadcaster language filter to Live Channels

### DIFF
--- a/components/Tasks/twitch-api-sdk/browse.bs
+++ b/components/Tasks/twitch-api-sdk/browse.bs
@@ -1,8 +1,13 @@
 function getBrowsePagePopularQuery() as object
+    language = get_user_setting("BrowseLanguage", "")
+    broadcasterLanguages = []
+    if language <> ""
+        broadcasterLanguages = [language]
+    end if
     variables = {
         "limit": 30,
         "sort": get_user_setting("LiveChannelSorting", "VIEWER_COUNT"),
-        "broadcasterLanguages": []
+        "broadcasterLanguages": broadcasterLanguages
     }
     if m.top.request.cursor <> invalid
         variables["after"] = m.top.request.cursor

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -151,5 +151,13 @@
             <source>Error: </source>
             <translation>Error: </translation>
         </message>
+        <message>
+            <source>Stream Language</source>
+            <translation>Stream Language</translation>
+        </message>
+        <message>
+            <source>Filter live streams on the Browse page by broadcaster language. Applies on next visit to Browse.</source>
+            <translation>Filter live streams on the Browse page by broadcaster language. Applies on next visit to Browse.</translation>
+        </message>
     </context>
 </TS>

--- a/locale/es_MX/translations.ts
+++ b/locale/es_MX/translations.ts
@@ -150,5 +150,13 @@
             <source>Error: </source>
             <translation>Error: </translation>
         </message>
+        <message>
+            <source>Stream Language</source>
+            <translation>Idioma de Transmisión</translation>
+        </message>
+        <message>
+            <source>Filter live streams on the Browse page by broadcaster language. Applies on next visit to Browse.</source>
+            <translation>Filtra transmisiones en vivo en la página Explorar por idioma del streamer. Se aplica en la próxima visita a Explorar.</translation>
+        </message>
     </context>
 </TS>

--- a/locale/pt_BR/translations.ts
+++ b/locale/pt_BR/translations.ts
@@ -149,5 +149,13 @@
             <source>Error: </source>
             <translation>Erro: </translation>
         </message>
+        <message>
+            <source>Stream Language</source>
+            <translation>Idioma da Transmissão</translation>
+        </message>
+        <message>
+            <source>Filter live streams on the Browse page by broadcaster language. Applies on next visit to Browse.</source>
+            <translation>Filtra transmissões ao vivo na página Navegar por idioma do streamer. Aplica-se na próxima visita ao Navegar.</translation>
+        </message>
     </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -109,6 +109,31 @@
         ]
     },
     {
+        "title": "Stream Language",
+        "description": "Filter live streams on the Browse page by broadcaster language. Applies on next visit to Browse.",
+        "settingName": "BrowseLanguage",
+        "type": "radio",
+        "default": "",
+        "options": [
+            { "title": "All Languages", "id": "" },
+            { "title": "English", "id": "en" },
+            { "title": "Español", "id": "es" },
+            { "title": "Português", "id": "pt" },
+            { "title": "Deutsch", "id": "de" },
+            { "title": "Français", "id": "fr" },
+            { "title": "Italiano", "id": "it" },
+            { "title": "한국어", "id": "ko" },
+            { "title": "日本語", "id": "ja" },
+            { "title": "中文", "id": "zh" },
+            { "title": "Polski", "id": "pl" },
+            { "title": "Русский", "id": "ru" },
+            { "title": "Türkçe", "id": "tr" },
+            { "title": "العربية", "id": "ar" },
+            { "title": "Tiếng Việt", "id": "vi" },
+            { "title": "ไทย", "id": "th" }
+        ]
+    },
+    {
         "title": "Offline Follow Sorting",
         "description": "Determines how the offline channels on the following page are sorted.",
         "settingName": "FollowPageSorting",


### PR DESCRIPTION
## Summary

- Adds a **Stream Language** radio setting (15 languages + All Languages default) in Settings, grouped with Live Channel Sorting
- `getBrowsePagePopularQuery()` reads the setting and passes `[]` or `["lang"]` to the `broadcasterLanguages` GraphQL variable — was hardcoded `[]`
- Translation keys added to en_US, pt_BR, and es_MX locale files

## Behavior

Default is empty string → empty array, so all existing users see no change. Setting a language filters the Live section on next Browse visit. Pagination re-reads the setting each call so the filter is consistent across all pages.

## T3 Finding (locale)

`Settings.brs` wraps all setting titles and descriptions in `tr()` (lines 73–74), so locale keys were required. Added to all three locale files.

## T4 Finding (scene lifecycle)

`build_Browse()` in `sceneFactory.brs` creates a fresh `roSGNode("Browse")` on every tab visit — no stale cursor concern when the language setting changes.

## Scope

Applies to Live Channels section only. Categories query (`directoriesWithTags`) has no `broadcasterLanguages` parameter. Featured is server-side personalized.

## QA

- `npm run lint && npm run fmt:check && npm run build` — clean ✅
- Rooibos: **118/118 tests pass** ✅
- TV QA (Settings radio picker scroll with 16 options): pending physical device verification