### PR TITLE
feat(config): namespace registry under separate section for dev builds

### DIFF
--- a/source/constants.brs
+++ b/source/constants.brs
@@ -14,9 +14,13 @@ sub setConstants()
             maxResolution = res.height
         end if
     end for
+    ' Sideloaded dev builds get a separate registry section so they don't share
+    ' login state or settings with the channel-store install.
+    appID = "StitchRevitalizedForRoku"
+    if appInfo.IsDev() then appID = appID + "Dev"
     ' Set Global Constants
     m.global.addFields({
-        appID: "StitchRevitalizedForRoku",
+        appID: appID,
         appInfo: {
             ID: appInfo.GetID(),
             IsDev: appInfo.IsDev(),


### PR DESCRIPTION
## Summary

Sideloaded dev builds now write to a separate registry section (`StitchRevitalizedForRokuDev`) instead of sharing one with the channel-store install. Fixes the case where login/logout in the dev build leaked into the production install on the same Roku (and vice versa).

## Change

One block in [`source/constants.brs`](../blob/feat/dev-registry-namespace/source/constants.brs#L17-L20):

```brightscript
appID = "StitchRevitalizedForRoku"
if appInfo.IsDev() then appID = appID + "Dev"
```

`roAppInfo.IsDev()` returns `true` for sideloaded builds and `false` for store-installed builds, so the split is automatic and requires no manifest or build flag changes.

## Effect

- **Store-installed builds** → registry section `StitchRevitalizedForRoku` (unchanged). All ~694K existing users keep their state.
- **Sideloaded dev builds** → registry section `StitchRevitalizedForRokuDev` (new, isolated).
- All downstream callers (`get_setting`, `set_user_setting`, `getTokenFromRegistry`, `NukeRegistry`, etc.) follow automatically because they all read `m.global.appid`.
- Per-user keys are namespaced under the global section's `active_user` value, so they split too without further work.

## Migration

None for production users. The first sideload after merging will appear logged out on the dev build (it's reading from the new empty section); log in once and the two installs are independent forever.

## Verification

- `npm run fmt:check` — clean
- `npm run lint` — clean