### PR TITLE
refactor: remove broadcaster language filter feature

### DIFF
--- a/components/Tasks/twitch-api-sdk/browse.bs
+++ b/components/Tasks/twitch-api-sdk/browse.bs
@@ -1,13 +1,7 @@
 function getBrowsePagePopularQuery() as object
-    language = get_user_setting("BrowseLanguage", "")
-    broadcasterLanguages = []
-    if language <> ""
-        broadcasterLanguages = [language]
-    end if
     variables = {
         "limit": 30,
-        "sort": get_user_setting("LiveChannelSorting", "VIEWER_COUNT"),
-        "broadcasterLanguages": broadcasterLanguages
+        "sort": get_user_setting("LiveChannelSorting", "VIEWER_COUNT")
     }
     if m.top.request.cursor <> invalid
         variables["after"] = m.top.request.cursor

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -143,21 +143,5 @@
             <source>Proxy not reachable</source>
             <translation>Proxy not reachable</translation>
         </message>
-        <message>
-            <source>Error: unknown failure. Try again.</source>
-            <translation>Error: unknown failure. Try again.</translation>
-        </message>
-        <message>
-            <source>Error: </source>
-            <translation>Error: </translation>
-        </message>
-        <message>
-            <source>Stream Language</source>
-            <translation>Stream Language</translation>
-        </message>
-        <message>
-            <source>Filter live streams on the Browse page by broadcaster language. Applies on next visit to Browse.</source>
-            <translation>Filter live streams on the Browse page by broadcaster language. Applies on next visit to Browse.</translation>
-        </message>
     </context>
 </TS>

--- a/locale/es_MX/translations.ts
+++ b/locale/es_MX/translations.ts
@@ -150,13 +150,5 @@
             <source>Error: </source>
             <translation>Error: </translation>
         </message>
-        <message>
-            <source>Stream Language</source>
-            <translation>Idioma de Transmisión</translation>
-        </message>
-        <message>
-            <source>Filter live streams on the Browse page by broadcaster language. Applies on next visit to Browse.</source>
-            <translation>Filtra transmisiones en vivo en la página Explorar por idioma del streamer. Se aplica en la próxima visita a Explorar.</translation>
-        </message>
     </context>
 </TS>

--- a/locale/pt_BR/translations.ts
+++ b/locale/pt_BR/translations.ts
@@ -150,12 +150,5 @@
             <translation>Erro: </translation>
         </message>
         <message>
-            <source>Stream Language</source>
-            <translation>Idioma da Transmissão</translation>
-        </message>
-        <message>
-            <source>Filter live streams on the Browse page by broadcaster language. Applies on next visit to Browse.</source>
-            <translation>Filtra transmissões ao vivo na página Navegar por idioma do streamer. Aplica-se na próxima visita ao Navegar.</translation>
-        </message>
     </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -109,31 +109,6 @@
         ]
     },
     {
-        "title": "Stream Language",
-        "description": "Filter live streams on the Browse page by broadcaster language. Applies on next visit to Browse.",
-        "settingName": "BrowseLanguage",
-        "type": "radio",
-        "default": "",
-        "options": [
-            { "title": "All Languages", "id": "" },
-            { "title": "English", "id": "en" },
-            { "title": "Español", "id": "es" },
-            { "title": "Português", "id": "pt" },
-            { "title": "Deutsch", "id": "de" },
-            { "title": "Français", "id": "fr" },
-            { "title": "Italiano", "id": "it" },
-            { "title": "한국어", "id": "ko" },
-            { "title": "日本語", "id": "ja" },
-            { "title": "中文", "id": "zh" },
-            { "title": "Polski", "id": "pl" },
-            { "title": "Русский", "id": "ru" },
-            { "title": "Türkçe", "id": "tr" },
-            { "title": "العربية", "id": "ar" },
-            { "title": "Tiếng Việt", "id": "vi" },
-            { "title": "ไทย", "id": "th" }
-        ]
-    },
-    {
         "title": "Offline Follow Sorting",
         "description": "Determines how the offline channels on the following page are sorted.",
         "settingName": "FollowPageSorting",

--- a/source/graphql/BrowseLiveChannels_Query.gql
+++ b/source/graphql/BrowseLiveChannels_Query.gql
@@ -2,11 +2,9 @@ query BrowseLiveChannels_Query(
             $limit: Int!
             $after: Cursor
             $sort: StreamSort
-            $broadcasterLanguages: [String!]
         ) {
             streams(first: $limit, after: $after, options: {
                 sort: $sort
-                broadcasterLanguages: $broadcasterLanguages
                 includeRestricted: ["SUB_ONLY_LIVE"]
             }) {
                 edges {


### PR DESCRIPTION
## Summary

- Removes the `BrowseLanguage` stream language filter setting entirely
- Drops `$broadcasterLanguages` variable from the `BrowseLiveChannels_Query` GQL query
- Cleans up the `getBrowsePagePopularQuery` function in `browse.bs` (no longer reads the `BrowseLanguage` registry key or builds the languages array)
- Removes the \"Stream Language\" setting UI entry from `settings/settings.json`
- Removes the corresponding translation strings from all three locale files (`en_US`, `es_MX`, `pt_BR`)

## Testing

- `bsc` build passes clean (exit 0, no errors or warnings)
- `brighterscript-formatter --check` passes on all changed `.bs` files