### PR TITLE
fix(tooling): repair signing pipeline and TaskControl enum values

### DIFF
--- a/components/Tasks/Analytics/AnalyticsTask.xml
+++ b/components/Tasks/Analytics/AnalyticsTask.xml
@@ -8,7 +8,7 @@
         <!-- Set to an assocarray with keys: message (string), number (integer), location (string) -->
         <field id="captureException" type="assocarray" alwaysNotify="true" />
     </interface>
-    <script type="text/brightscript" uri="AnalyticsTask.bs" />
+    <script type="text/brightscript" uri="pkg:/components/Tasks/Analytics/AnalyticsTask.bs" />
     <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
 </component>

--- a/components/Tasks/twitch-api-sdk/TwitchApiTask.xml
+++ b/components/Tasks/twitch-api-sdk/TwitchApiTask.xml
@@ -9,16 +9,16 @@
     </interface>
     <script type="text/brightscript" uri="pkg:/source/enums/TaskControl.bs" />
     <script type="text/brightscript" uri="pkg:/source/enums/ContentType.bs" />
-    <script type="text/brightscript" uri="shared.bs" />
-    <script type="text/brightscript" uri="auth.bs" />
-    <script type="text/brightscript" uri="player.bs" />
-    <script type="text/brightscript" uri="channel.bs" />
-    <script type="text/brightscript" uri="home.bs" />
-    <script type="text/brightscript" uri="game.bs" />
-    <script type="text/brightscript" uri="browse.bs" />
-    <script type="text/brightscript" uri="search.bs" />
-    <script type="text/brightscript" uri="user.bs" />
-    <script type="text/brightscript" uri="follow.bs" />
+    <script type="text/brightscript" uri="pkg:/components/Tasks/twitch-api-sdk/shared.bs" />
+    <script type="text/brightscript" uri="pkg:/components/Tasks/twitch-api-sdk/auth.bs" />
+    <script type="text/brightscript" uri="pkg:/components/Tasks/twitch-api-sdk/player.bs" />
+    <script type="text/brightscript" uri="pkg:/components/Tasks/twitch-api-sdk/channel.bs" />
+    <script type="text/brightscript" uri="pkg:/components/Tasks/twitch-api-sdk/home.bs" />
+    <script type="text/brightscript" uri="pkg:/components/Tasks/twitch-api-sdk/game.bs" />
+    <script type="text/brightscript" uri="pkg:/components/Tasks/twitch-api-sdk/browse.bs" />
+    <script type="text/brightscript" uri="pkg:/components/Tasks/twitch-api-sdk/search.bs" />
+    <script type="text/brightscript" uri="pkg:/components/Tasks/twitch-api-sdk/user.bs" />
+    <script type="text/brightscript" uri="pkg:/components/Tasks/twitch-api-sdk/follow.bs" />
     <script type="text/brightscript" uri="pkg:/source/utils/http.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "fmt": "brighterscript-formatter --write 'source/**/*.{brs,bs}' 'components/**/*.{brs,bs}'",
     "fmt:check": "brighterscript-formatter --check 'source/**/*.{brs,bs}' 'components/**/*.{brs,bs}'",
     "test": "bsc --project bsconfig.test.json --create-package && node tools/deploy-test.js",
-    "prepare": "husky"
+    "prepare": "husky",
+    "sign": "node scripts/sign-package.js"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.5.3",

--- a/scripts/sign-package.js
+++ b/scripts/sign-package.js
@@ -82,8 +82,7 @@ async function main() {
         const deviceInfo = await rokuDeploy.getDeviceInfo({ host: HOST, password: PASSWORD });
         const devId = deviceInfo["keyed-developer-id"];
         console.log(`>>  DevID: ${devId}`);
-        console.log(">>  Verify this matches the DevID on the Roku Developer Dashboard");
-        console.log(">>  for channel 817397 before uploading.");
+        console.log(">>  Verify this matches the DevID on the Roku Developer Dashboard before uploading.");
     } catch (err) {
         console.warn(`>>  (could not fetch DevID: ${err.message})`);
     }

--- a/scripts/sign-package.js
+++ b/scripts/sign-package.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+const path = require("node:path");
+const fs = require("node:fs");
+
+const rokuDeploy = require("roku-deploy");
+
+const HOST = process.env.ROKU_HOST || "192.168.0.157";
+const PASSWORD = process.env.ROKU_PASSWORD || "oscarjo";
+const ROOT_DIR = path.resolve(__dirname, "..");
+const OUT_DIR = path.join(ROOT_DIR, "out");
+const OUT_FILE = "Stitch-Revitalized-For-Roku";
+
+function fail(msg) {
+    console.error(`error: ${msg}`);
+    process.exit(1);
+}
+
+function readSigningPassword() {
+    const cliArg = process.argv[2];
+    if (cliArg && cliArg.trim()) return cliArg.trim();
+    if (process.env.ROKU_SIGNING_PASSWORD) return process.env.ROKU_SIGNING_PASSWORD;
+    fail(
+        "missing signing password\n" +
+        "usage:  node scripts/sign-package.js <signing-password>\n" +
+        "  or:   ROKU_SIGNING_PASSWORD=... node scripts/sign-package.js"
+    );
+}
+
+function readManifest() {
+    const text = fs.readFileSync(path.join(ROOT_DIR, "manifest"), "utf8");
+    const get = (k) => {
+        const m = text.match(new RegExp(`^${k}=(.*)$`, "m"));
+        return m ? m[1].trim() : null;
+    };
+    const title = get("title") || fail("manifest missing title");
+    const major = get("major_version") || fail("manifest missing major_version");
+    const minor = get("minor_version") || fail("manifest missing minor_version");
+    const build = get("build_version") || "0";
+    return { title, major, minor, build, version: `${major}.${minor}.${build}` };
+}
+
+async function main() {
+    const signingPassword = readSigningPassword();
+    const manifest = readManifest();
+
+    fs.mkdirSync(OUT_DIR, { recursive: true });
+
+    const options = {
+        host: HOST,
+        password: PASSWORD,
+        signingPassword,
+        rootDir: ROOT_DIR,
+        outDir: OUT_DIR,
+        outFile: OUT_FILE,
+        files: [
+            "manifest",
+            "source/**/*",
+            "components/**/*",
+            "images/**/*",
+            "fonts/**/*",
+            "locale/**/*",
+            "settings/**/*",
+        ],
+        retainStagingDir: false,
+    };
+
+    console.log(`>>  ${manifest.title} v${manifest.version}`);
+    console.log(`>>  TV: ${HOST}`);
+    console.log(`>>  Output: ${path.join(OUT_DIR, OUT_FILE)}.pkg`);
+    console.log("");
+    console.log(">>  [1/3] zipping + sideloading to TV...");
+    console.log(">>  [2/3] signing package on TV...");
+    console.log(">>  [3/3] downloading signed .pkg...");
+    console.log("");
+
+    const pkgPath = await rokuDeploy.deployAndSignPackage(options);
+    console.log("");
+    console.log(`>>  signed package: ${pkgPath}`);
+
+    const stats = fs.statSync(pkgPath);
+    console.log(`>>  size: ${(stats.size / 1024).toFixed(1)} KB`);
+
+    console.log("");
+    console.log(">>  fetching DevID for sanity check...");
+    try {
+        const devId = await rokuDeploy.getDevId({ host: HOST, password: PASSWORD });
+        console.log(`>>  DevID: ${devId}`);
+        console.log(">>  Verify this matches the DevID on the Roku Developer Dashboard");
+        console.log(">>  for channel 817397 before uploading.");
+    } catch (err) {
+        console.warn(`>>  (could not fetch DevID: ${err.message})`);
+    }
+
+    console.log("");
+    console.log(">>  Done. Upload the .pkg to the Roku Developer Dashboard:");
+    console.log(`>>    ${pkgPath}`);
+}
+
+main().catch((err) => {
+    console.error("");
+    console.error("FAILED:", err.message || err);
+    if (err && err.results && err.results.body) {
+        const body = String(err.results.body).slice(0, 500);
+        console.error("device response (first 500 chars):", body);
+    }
+    process.exit(1);
+});

--- a/scripts/sign-package.js
+++ b/scripts/sign-package.js
@@ -4,8 +4,6 @@ const fs = require("node:fs");
 
 const rokuDeploy = require("roku-deploy");
 
-const HOST = process.env.ROKU_HOST || "192.168.0.157";
-const PASSWORD = process.env.ROKU_PASSWORD || "oscarjo";
 const ROOT_DIR = path.resolve(__dirname, "..");
 const OUT_DIR = path.join(ROOT_DIR, "out");
 const OUT_FILE = "Stitch-Revitalized-For-Roku";
@@ -14,6 +12,9 @@ function fail(msg) {
     console.error(`error: ${msg}`);
     process.exit(1);
 }
+
+const HOST = process.env.ROKU_HOST || fail("missing ROKU_HOST env var\nusage: ROKU_HOST=<ip> ROKU_PASSWORD=<pw> ROKU_SIGNING_PASSWORD=<pw> npm run sign");
+const PASSWORD = process.env.ROKU_PASSWORD || fail("missing ROKU_PASSWORD env var\nusage: ROKU_HOST=<ip> ROKU_PASSWORD=<pw> ROKU_SIGNING_PASSWORD=<pw> npm run sign");
 
 function readSigningPassword() {
     const cliArg = process.argv[2];
@@ -45,35 +46,30 @@ async function main() {
 
     fs.mkdirSync(OUT_DIR, { recursive: true });
 
-    const options = {
+    const zipPath = path.join(OUT_DIR, `${OUT_FILE}.zip`);
+    if (!fs.existsSync(zipPath)) {
+        fail(`pre-built zip not found at ${zipPath} — run 'npm run package' first`);
+    }
+
+    const baseOptions = {
         host: HOST,
         password: PASSWORD,
-        signingPassword,
-        rootDir: ROOT_DIR,
         outDir: OUT_DIR,
         outFile: OUT_FILE,
-        files: [
-            "manifest",
-            "source/**/*",
-            "components/**/*",
-            "images/**/*",
-            "fonts/**/*",
-            "locale/**/*",
-            "settings/**/*",
-        ],
-        retainStagingDir: false,
     };
 
     console.log(`>>  ${manifest.title} v${manifest.version}`);
     console.log(`>>  TV: ${HOST}`);
     console.log(`>>  Output: ${path.join(OUT_DIR, OUT_FILE)}.pkg`);
     console.log("");
-    console.log(">>  [1/3] zipping + sideloading to TV...");
+    console.log(">>  [1/3] sideloading pre-built zip to TV...");
     console.log(">>  [2/3] signing package on TV...");
     console.log(">>  [3/3] downloading signed .pkg...");
     console.log("");
 
-    const pkgPath = await rokuDeploy.deployAndSignPackage(options);
+    await rokuDeploy.publish(baseOptions);
+    const remotePkgPath = await rokuDeploy.signExistingPackage({ ...baseOptions, signingPassword });
+    const pkgPath = await rokuDeploy.retrieveSignedPackage(remotePkgPath, baseOptions);
     console.log("");
     console.log(`>>  signed package: ${pkgPath}`);
 
@@ -83,7 +79,8 @@ async function main() {
     console.log("");
     console.log(">>  fetching DevID for sanity check...");
     try {
-        const devId = await rokuDeploy.getDevId({ host: HOST, password: PASSWORD });
+        const deviceInfo = await rokuDeploy.getDeviceInfo({ host: HOST, password: PASSWORD });
+        const devId = deviceInfo["keyed-developer-id"];
         console.log(`>>  DevID: ${devId}`);
         console.log(">>  Verify this matches the DevID on the Roku Developer Dashboard");
         console.log(">>  for channel 817397 before uploading.");

--- a/source/enums/TaskControl.bs
+++ b/source/enums/TaskControl.bs
@@ -1,5 +1,5 @@
 enum TaskControl
-    RUN = "run"
-    stop = "stop"
-    START = "start"
+    RUN = "RUN"
+    stop = "STOP"
+    START = "START"
 end enum


### PR DESCRIPTION
## Summary

- **`TaskControl` enum values were lowercase** (`"stop"`, `"run"`, `"start"`) — Roku's task control field is case-sensitive and silently ignores lowercase values, causing Task nodes to never stop. Fixed to `"STOP"`, `"RUN"`, `"START"`.

- **`sign-package.js` bypassed BSC entirely** — `deployAndSignPackage` re-zips raw source files, skipping transpilation. BrighterScript features (`const`, `enum`, `namespace`) in `.bs` files then hit the Roku runtime compiler which rejects them. Fixed by splitting into `publish` (sideloads the pre-built BSC zip from `npm run package`) + `signExistingPackage` + `retrieveSignedPackage`.

- **Relative `uri=` in Task XMLs prevented BSC from transpiling** — `uri="AnalyticsTask.bs"` and `uri="shared.bs"` etc. caused BSC to copy raw `.bs` files into the zip instead of transpiling them to `.brs`. Fixed by switching to absolute `pkg:/` URIs in `AnalyticsTask.xml` and `TwitchApiTask.xml`.

- **Hardcoded device credentials removed** from `sign-package.js` — `ROKU_HOST` and `ROKU_PASSWORD` are now required env vars; the script fails with a clear usage message if either is missing.

## How to sign

```bash
npm run package
ROKU_HOST=<ip> ROKU_PASSWORD=<pw> ROKU_SIGNING_PASSWORD=<pw> npm run sign
```