### PR TITLE
fix: chat teardown + remove stop debugger from select()

### DIFF
--- a/components/Modules/Chat/Chat.brs
+++ b/components/Modules/Chat/Chat.brs
@@ -20,9 +20,6 @@ sub updatePanelTranslation()
 end sub
 
 sub setSizingParameters()
-    '@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-    ' Size and Spacing Settings
-    '@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
     m.left_bound = m.font_size / 2
     m.right_bound = m.chatPanel.width - m.font_size
     m.badge_size = (m.font_size * 1.6)
@@ -32,13 +29,10 @@ sub setSizingParameters()
     m.message_height = (m.badge_size * 1.8)
 
     m.lower_bound = m.chatPanel.height - m.message_height
-    '@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 end sub
 
 sub setChatPanelSize()
     m.font_size = m.top.fontSize
-    ' m.chatPanel.width = m.global.constants.screenWidth
-    ' m.chatPanel.height = m.global.constants.screenHeight
     m.translation = m.chatPanel.height - m.font_size
     m.lower_bound = m.chatPanel.height - m.font_size
     m.right_bound = m.chatPanel.width - m.font_size
@@ -76,7 +70,6 @@ sub onVideoChange()
 end sub
 
 sub onEnterChannel()
-    ' ? "Chat >> onEnterChannel > " m.top.channel
     m.chat = m.top.findnode("ChatJob")
     m.chat.forceLive = m.top.forceLive
     m.chat.observeField("nextCommentObj", "onNewCommentObj")
@@ -170,9 +163,6 @@ function buildColon()
     return colon
 end function
 
-
-
-
 function wordOrImage(word, isUrl = false)
     if m.global.emoteCache.DoesExist(word)
         return buildEmote(m.global.emoteCache[word])
@@ -188,8 +178,6 @@ function wordOrImage(word, isUrl = false)
         return message_text
     end if
 end function
-
-'
 
 function buildMessage(message, x_translation)
     message_group = createObject("roSGNode", "Group")
@@ -207,12 +195,6 @@ function buildMessage(message, x_translation)
 
         block = wordOrImage(word, isUrl)
         block_width = block.localBoundingRect().width
-        '* '  "Useful for Debug"
-        ' ? "left_bound: " m.left_bound
-        ' ? "right_bound: " m.right_bound
-        ' ? "x_translation: " x_translation
-        ' ? "Block Width: " block_width
-        ' ? "line_available_space: " line_available_space
         if block_width > m.right_bound
             ? "break it up!"
             block = createObject("roSGNode", "Group")
@@ -267,7 +249,6 @@ sub onNewCommentObj()
         badges = []
         if comment?.tags?.badges <> invalid
             for each key in comment.tags.badges
-                ' badgeID = key + "/" + comment.tags.badges[key]
                 badgeID = key
                 badges.push(badgeID)
             end for
@@ -286,7 +267,6 @@ sub onNewCommentObj()
 
         quoteRegex = createObject("roRegex", "[\x{2018}\x{2019}]", "")
         message = quoteRegex.replace(message, "'")
-        ' This Section grabs missing emotes on the fly... not sure if there is a better way to optimize.
         for each emoticon in emote_set.Items()
             e_start = emoticon.value.starts[0]
             emote_word = Mid(message, (e_start + 1), emoticon.value.length)

--- a/components/Modules/Chat/Chat.brs
+++ b/components/Modules/Chat/Chat.brs
@@ -53,12 +53,18 @@ sub onInvisible()
     end if
 end sub
 
+' Stops the ChatJob (IRC) and EmoteJob tasks and releases their observers.
+' Called from VideoPlayer.exitPlayer() so the IRC socket loop and emote
+' fetcher are torn down at user-initiated exit, not just when SceneGraph
+' eventually fires onDestroy.
+'
+' Uses destroyTask() per AGENTS.md: unobserve first so any in-flight
+' nextCommentObj callback is suppressed before the task thread halts.
 sub stopJobs()
-    if m.chat <> invalid
-        m.chat.control = "stop"
-    end if
+    m.chat = destroyTask(m.chat, "nextCommentObj")
     if m.EmoteJob <> invalid
         m.EmoteJob.control = "stop"
+        m.EmoteJob = invalid
     end if
 end sub
 

--- a/source/tests/misc.spec.bs
+++ b/source/tests/misc.spec.bs
@@ -432,6 +432,16 @@ namespace tests
             m.assertEqual(result[4], 5)
         end sub
 
+        @it("returns empty array when step is zero")
+        sub select_zeroStep()
+            ' step=0 used to drop into the BrightScript debugger via `stop`,
+            ' which halts the channel on production devices. The helper now
+            ' logs a ValueError and returns [] gracefully.
+            result = select([1, 2, 3, 4, 5], 0, 4, 0)
+            m.assertEqual(type(result), "roArray")
+            m.assertEqual(result.count(), 0)
+        end sub
+
         '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
         @describe("isChainValid")
         '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -271,7 +271,10 @@ function toString(input) as string
 end function
 
 function select(arr, start = invalid, finish = invalid, step_ = 1):
-    if step_ = 0 then print "ValueError: slice step cannot be zero" : stop
+    if step_ = 0
+        ? "ValueError: slice step cannot be zero"
+        return []
+    end if
     if start = invalid then if step_ > 0 then start = 0 else start = arr.count() - 1
     if finish = invalid then if step_ > 0 then finish = arr.count() - 1 else finish = 0
     if start < 0 then start = arr.count() + start 'negative counts backwards from the end


### PR DESCRIPTION
## Summary

Addresses the first two **High Priority** items from `TODO.md`.

### 1. Chat job not stopped cleanly when leaving a live stream
`Chat.stopJobs()` (called from `VideoPlayer.exitPlayer()` on user back-out) previously set `ChatJob.control = \"stop\"` without unobserving `nextCommentObj` first. Per AGENTS.md, tasks must be torn down via `destroyTask()` so the unobserve happens before the thread halts — otherwise an in-flight IRC response can still dispatch `onNewCommentObj` while the scene is being removed.

`stopJobs()` now uses `destroyTask(m.chat, \"nextCommentObj\")` and clears `m.EmoteJob` after stopping. Composes safely with `Chat.onDestroy()`, which still runs `destroyTask(m.chat, ...)` when the scene tree is removed — passing `invalid` through `destroyTask()` is a no-op.

### 2. `stop` debugger statement in `select()` slice helper
`source/utils/misc.brs::select()` raised `stop` when `step_ = 0`, which drops into the BrightScript debugger on dev builds and crashes the channel back to the home screen on production devices. Flagged by Roku static analysis (\"STOP command is present\"). The branch is dead code in practice (no caller passes `step_=0`), but `stop` should not ship. Replaced with a logged `ValueError` and an empty-array return, matching Python slice semantics. Added a Rooibos test covering the new behaviour.

## Verification

- `npm run lint` — clean
- `npm run fmt:check` — clean
- `npm run build` — clean
- `npm test` (rooibos on local simulator) — **119/119 passed**, including the new `select` zero-step case