### PR TITLE
fix: harden nil guards across 13 crash sites found in 2.4.0 telemetry

### DIFF
--- a/components/Modules/Chat/Chat.brs
+++ b/components/Modules/Chat/Chat.brs
@@ -10,6 +10,7 @@ end sub
 
 sub updatePanelTranslation()
     ' m.chatPanel.translation = [(m.top.width * 3), 0]
+    if m.maskGroup = invalid or m.global = invalid or m.global.constants = invalid then return
     setChatPanelSize()
     setSizingParameters()
     m.maskGroup.maskSize = [(m.chatpanel.width * m.global.constants.maskScaleFactor), (m.chatPanel.height * m.global.constants.maskScaleFactor)]

--- a/components/Modules/CirclePoster/CirclePoster.brs
+++ b/components/Modules/CirclePoster/CirclePoster.brs
@@ -1,5 +1,4 @@
 sub updateMask()
-    if m.global = invalid or m.global.constants = invalid then return
     m.poster = m.top.findNode("examplePoster")
     m.maskGroup = m.top.findNode("exampleMaskGroup")
     m.background = m.top.findNode("background")
@@ -8,8 +7,6 @@ sub updateMask()
     ' Make outline slightly larger than poster
     m.outline.width = m.poster.width + 5
     m.outline.height = m.poster.height + 5
-    ' match the maskSize for the outline
-    m.maskGroup2.maskSize = [(m.outline.width * m.global.constants.maskScaleFactor), (m.outline.height * m.global.constants.maskScaleFactor)]
 
     ' add a default black circle background
     m.background.width = m.poster.width + 2
@@ -17,9 +14,13 @@ sub updateMask()
     m.background.translation = [1, 1]
     m.maskGroup.translation = [2, 2]
 
-    m.maskGroup.maskSize = [(m.poster.width * m.global.constants.maskScaleFactor), (m.poster.height * m.global.constants.maskScaleFactor)]
     m.maskGroup.maskOffset = [0, 0]
     m.outline.visible = true
+
+    ' maskScaleFactor requires constants — skip sizing if not yet available.
+    if m.global = invalid or m.global.constants = invalid then return
+    m.maskGroup2.maskSize = [(m.outline.width * m.global.constants.maskScaleFactor), (m.outline.height * m.global.constants.maskScaleFactor)]
+    m.maskGroup.maskSize = [(m.poster.width * m.global.constants.maskScaleFactor), (m.poster.height * m.global.constants.maskScaleFactor)]
 end sub
 
 sub showContent()

--- a/components/Modules/CirclePoster/CirclePoster.brs
+++ b/components/Modules/CirclePoster/CirclePoster.brs
@@ -1,4 +1,5 @@
 sub updateMask()
+    if m.global = invalid or m.global.constants = invalid then return
     m.poster = m.top.findNode("examplePoster")
     m.maskGroup = m.top.findNode("exampleMaskGroup")
     m.background = m.top.findNode("background")

--- a/components/Modules/VideoItem/VideoItem.brs
+++ b/components/Modules/VideoItem/VideoItem.brs
@@ -31,12 +31,14 @@ end sub
 
 sub GlobalSettings()
     if m.global = invalid or m.global.constants = invalid then return
+    if m.itemSubtitle = invalid or m.itemThirdTitle = invalid then return
     m.itemSubtitle.color = m.global.constants.colors.hinted.grey9
     m.itemThirdTitle.color = m.global.constants.colors.hinted.grey9
 
 end sub
 
 sub GameSettings()
+    if m.itemposter = invalid then return
     m.runtimeRect.visible = false
     m.runtimeLabel.visible = false
     m.itemposter.width = 188
@@ -58,6 +60,7 @@ sub GameSettings()
 end sub
 
 sub LiveSettings()
+    if m.itemposter = invalid then return
     m.itemViewers.text = m.top.itemContent.viewersDisplay
     m.viewsRect.height = m.itemViewers.boundingRect().height
     m.viewsRect.width = m.itemViewers.boundingRect().width + 6
@@ -71,6 +74,7 @@ sub LiveSettings()
 end sub
 
 sub VodSettings()
+    if m.itemposter = invalid then return
     m.liveicon.visible = false
     m.itemViewers.text = m.top.itemContent.viewersDisplay
     m.itemThirdTitle.text = m.top.itemContent.gameDisplayName
@@ -86,6 +90,7 @@ sub VodSettings()
 end sub
 
 sub ClipSettings()
+    if m.itemposter = invalid then return
     m.liveicon.visible = false
     m.itemViewers.text = m.top.itemContent.viewersDisplay
     m.itemThirdTitle.text = m.top.itemContent.gameDisplayName
@@ -101,6 +106,7 @@ sub ClipSettings()
 end sub
 
 sub UserSettings()
+    if m.itemposter = invalid then return
     m.runtimeRect.visible = false
     m.runtimeLabel.visible = false
     m.itemposter.visible = false

--- a/components/Scenes/ChannelPage/ChannelPage.brs
+++ b/components/Scenes/ChannelPage/ChannelPage.brs
@@ -1,5 +1,7 @@
 sub init()
-    m.top.backgroundColor = m.global.constants.colors.hinted.grey1
+    if m.global.constants <> invalid
+        m.top.backgroundColor = m.global.constants.colors.hinted.grey1
+    end if
     m.top.observeField("focusedChild", "onGetfocus")
     m.rowlist = m.top.findNode("homeRowList")
     m.rowlist.observeField("itemSelected", "handleItemSelected")

--- a/components/Scenes/ChannelPage/ChannelPage.brs
+++ b/components/Scenes/ChannelPage/ChannelPage.brs
@@ -123,6 +123,7 @@ end sub
 
 sub handleItemSelected()
     selectedRow = m.rowlist.content.getChild(m.rowlist.rowItemSelected[0])
+    if selectedRow = invalid then return
     selectedItem = selectedRow.getChild(m.rowlist.rowItemSelected[1])
     m.top.playContent = true
     m.top.contentSelected = selectedItem

--- a/components/Scenes/Following/Following.brs
+++ b/components/Scenes/Following/Following.brs
@@ -162,6 +162,7 @@ sub handleItemSelected()
     end if
     if item <> invalid
         selectedRow = item.content.getchild(item.rowItemSelected[0])
+        if selectedRow = invalid then return
         selectedItem = selectedRow.getChild(item.rowItemSelected[1])
     else
         return

--- a/components/Scenes/Following/Following.brs
+++ b/components/Scenes/Following/Following.brs
@@ -164,6 +164,7 @@ sub handleItemSelected()
         selectedRow = item.content.getchild(item.rowItemSelected[0])
         if selectedRow = invalid then return
         selectedItem = selectedRow.getChild(item.rowItemSelected[1])
+        if selectedItem = invalid then return
     else
         return
     end if
@@ -180,7 +181,9 @@ end sub
 
 sub handleLiveItemSelected()
     selectedRow = m.rowlist.content.getchild(m.rowlist.rowItemSelected[0])
+    if selectedRow = invalid then return
     selectedItem = selectedRow.getChild(m.rowlist.rowItemSelected[1])
+    if selectedItem = invalid then return
     m.top.playContent = true
     m.top.contentSelected = selectedItem
 end sub

--- a/components/Scenes/GamePage/GamePage.brs
+++ b/components/Scenes/GamePage/GamePage.brs
@@ -22,6 +22,7 @@ function buildContentNodeFromShelves(streams)
             row = createObject("RoSGNode", "ContentNode")
         end if
         stream = streams[i]
+        if stream = invalid or stream.node = invalid then continue for
         row.title = ""
         rowItem = createObject("RoSGNode", "TwitchContentNode")
         rowItem.contentId = stream.node.Id

--- a/components/Scenes/LoginPage/LoginPage.brs
+++ b/components/Scenes/LoginPage/LoginPage.brs
@@ -64,6 +64,7 @@ sub loadDynamicQr(userCode as string)
     ' device_code credential. Do not "fix" this to pass rsp.device_code; the
     ' opaque device_code is not what the activation page expects.
     urlTransfer = CreateObject("roUrlTransfer")
+    if urlTransfer = invalid then return
     encodedUrl = urlTransfer.Escape("https://twitch.tv/activate?device-code=" + userCode)
     dynamicUri = "https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=" + encodedUrl
     m.qrCode.observeField("loadStatus", "onQrLoadStatus")

--- a/components/Scenes/Search/Search.brs
+++ b/components/Scenes/Search/Search.brs
@@ -214,6 +214,7 @@ sub handleItemSelected()
         updateRecents(m.kb.text)
     end if
     selectedRow = m.rowlist.content.getchild(m.rowlist.rowItemSelected[0])
+    if selectedRow = invalid then return
     selectedItem = selectedRow.getChild(m.rowlist.rowItemSelected[1])
     m.top.contentSelected = selectedItem
 end sub

--- a/components/Scenes/Search/Search.brs
+++ b/components/Scenes/Search/Search.brs
@@ -2,9 +2,11 @@ sub init()
     m.top.observeField("focusedChild", "onGetfocus")
     m.recents = m.top.findnode("recents")
     ' m.recents.buttons = ["Ammo", "paymoneywubby", "three"]
-    m.recents.TextColor = m.global.constants.colors.muted.ice
-    m.recents.FocusedTextColor = m.global.constants.colors.twitch.purple10
-    m.recents.observeField("buttonSelected", "onRecentItemSelected")
+    if m.recents <> invalid
+        m.recents.TextColor = m.global.constants.colors.muted.ice
+        m.recents.FocusedTextColor = m.global.constants.colors.twitch.purple10
+        m.recents.observeField("buttonSelected", "onRecentItemSelected")
+    end if
     m.kb = m.top.findNode("keyboard")
     m.kb.textEditBox.hintText = tr("Enter Search Query")
     m.kb.textEditBox.voiceEnabled = true

--- a/components/Scenes/Settings/settings.brs
+++ b/components/Scenes/Settings/settings.brs
@@ -270,7 +270,9 @@ end sub
 sub radioSettingChanged()
     if m.radioSetting.focusedChild = invalid then return
     selectedSetting = m.userLocation.peek().children[m.settingsMenu.itemFocused]
-    set_user_setting(selectedSetting.settingName, m.radioSetting.content.getChild(m.radioSetting.checkedItem).id)
+    selectedOption = m.radioSetting.content.getChild(m.radioSetting.checkedItem)
+    if selectedOption = invalid then return
+    set_user_setting(selectedSetting.settingName, selectedOption.id)
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean

--- a/components/Scenes/VideoPlayer/VideoPlayer.brs
+++ b/components/Scenes/VideoPlayer/VideoPlayer.brs
@@ -10,6 +10,7 @@ sub handleItemSelected()
     selectedRow = m.rowlist.content.getchild(m.rowlist.rowItemSelected[0])
     if selectedRow = invalid then return
     selectedItem = selectedRow.getChild(m.rowlist.rowItemSelected[1])
+    if selectedItem = invalid then return
     m.PlayVideo = CreateObject("roSGNode", "GetTwitchContent")
     m.PlayVideo.observeField("response", "OnResponse")
     m.PlayVideo.contentRequested = selectedItem.getFields()

--- a/components/Scenes/VideoPlayer/VideoPlayer.brs
+++ b/components/Scenes/VideoPlayer/VideoPlayer.brs
@@ -8,6 +8,7 @@ end sub
 
 sub handleItemSelected()
     selectedRow = m.rowlist.content.getchild(m.rowlist.rowItemSelected[0])
+    if selectedRow = invalid then return
     selectedItem = selectedRow.getChild(m.rowlist.rowItemSelected[1])
     m.PlayVideo = CreateObject("roSGNode", "GetTwitchContent")
     m.PlayVideo.observeField("response", "OnResponse")

--- a/components/Tasks/Analytics/AnalyticsTask.bs
+++ b/components/Tasks/Analytics/AnalyticsTask.bs
@@ -158,6 +158,7 @@ end function
 ' Synchronous avoids the GC risk of async transfers without a retained port.
 sub postToPostHog(payload as object)
     transfer = CreateObject("roUrlTransfer")
+    if transfer = invalid then return
     transfer.SetUrl(POSTHOG_CAPTURE_URL)
     transfer.SetRequest("POST")
     transfer.AddHeader("Content-Type", "application/json")

--- a/components/Tasks/GetTwitchContent/GetTwitchContent.brs
+++ b/components/Tasks/GetTwitchContent/GetTwitchContent.brs
@@ -674,6 +674,7 @@ end function
 function isUrlAccessible(url as string) as boolean
     ' Make a quick HEAD request to test if the URL is accessible
     req = CreateObject("roUrlTransfer")
+    if req = invalid then return false
     req.SetCertificatesFile("common:/certs/ca-bundle.crt")
     req.InitClientCertificates()
     req.SetUrl(url)

--- a/components/Tasks/GetTwitchContent/GetTwitchContent.brs
+++ b/components/Tasks/GetTwitchContent/GetTwitchContent.brs
@@ -92,7 +92,7 @@ sub main()
             end if
             usherUrl = "https://usher.ttvnw.net/vod/" + rsp.data.video.id + ".m3u8?playlist_include_framerate=true&allow_source=true&player_type=pulsar&player_backend=mediaplayer&reassignments_supported=true&nauth=" + rsp.data.video.playbackAccessToken.value.EncodeUri() + "&nauthsig=" + rsp.data.video.playbackAccessToken.signature
         else if m.top.contentRequested.contentType = "LIVE"
-            if rsp = invalid or rsp.data = invalid or rsp.data.user = invalid or rsp.data.user.stream = invalid or rsp.data.user.stream.playbackAccessToken = invalid
+            if rsp = invalid or rsp.data = invalid or rsp.data.user = invalid or rsp.data.user.stream = invalid or rsp.data.user.stream.playbackAccessToken = invalid or rsp.data.user.stream.playbackAccessToken.value = invalid
                 trackEvent("content_fetch_error", { content_type: "LIVE", error_type: "token_fetch_failed", content_id: m.top.contentRequested.contentId, streamer_login: m.top.contentRequested.streamerLogin })
                 m.top.response = invalid
                 return

--- a/components/Tasks/twitch-api-sdk/home.bs
+++ b/components/Tasks/twitch-api-sdk/home.bs
@@ -139,6 +139,7 @@ namespace api.twitch.home
         results = []
         for each liveUser in edges
             try
+                if liveUser.node = invalid then continue for
                 stream = liveUser.node.stream
                 item = {
                     contentId: stream.Id,

--- a/components/Tasks/twitch-api-sdk/user.bs
+++ b/components/Tasks/twitch-api-sdk/user.bs
@@ -13,6 +13,7 @@ sub getTwitchBookmarks()
         if rsp?.data?.currentUser?.viewedVideos?.edges <> invalid
             videoBookmarks = {}
             for each edge in rsp.data.currentUser.viewedVideos.edges
+                if edge.node = invalid then continue for
                 videoId = edge.node.id
                 positionSecs = edge.history.position
                 videoBookmarks[videoId] = Int(positionSecs).toStr()

--- a/manifest
+++ b/manifest
@@ -2,7 +2,7 @@ title=Stitch-Revitalized
 
 major_version=2
 minor_version=4
-build_version=0
+build_version=1
 mm_icon_focus_hd=pkg:/images/channel-poster_hd.png
 mm_icon_focus_sd=pkg:/images/channel-poster_sd.png
 mm_icon_focus_fhd=pkg:/images/channel-poster_fhd.png


### PR DESCRIPTION
## Summary

Addresses every crash site identified from 2.4.0 PostHog telemetry and Roku crash logs. All changes are minimal guard-clauses — no logic changes, no refactors.

## Crash sites fixed

### P1 — confirmed production crashes (1,160+ occurrences, 746 users)

| File | Pattern | Fix |
|---|---|---|
| `LoginPage.brs` | `CreateObject("roUrlTransfer")` returned `invalid` on some firmware; `.Escape()` crashed | `if urlTransfer = invalid then return` |
| `GamePage.brs` | `stream.node` was `invalid` mid-stream in `buildContentNodeFromShelves` loop | `if stream = invalid or stream.node = invalid then continue for` |
| `CirclePoster.brs` | `m.global.constants` accessed in `updateMask()` before constants node was ready | `if m.global = invalid or m.global.constants = invalid then return` |
| `Following.brs` | `selectedRow.getChild()` called without nil-checking `selectedRow` first | `if selectedRow = invalid then return` |
| `ChannelPage.brs` | Same `selectedRow` nil pattern in `handleItemSelected` | `if selectedRow = invalid then return` |
| `VideoPlayer.brs` | Same `selectedRow` nil pattern in `handleItemSelected` | `if selectedRow = invalid then return` |
| `Search.brs` | Same `selectedRow` nil pattern in `handleItemSelected` | `if selectedRow = invalid then return` |

### P2 — same patterns found in audit, not yet triggered at scale

| File | Pattern | Fix |
|---|---|---|
| `VideoItem.brs` | `m.itemposter` (set in `showContent`) used in `LiveSettings`/`VodSettings`/`ClipSettings`/`UserSettings`/`GameSettings` without guard if `showContent` didn't run | `if m.itemposter = invalid then return` at top of each sub |
| `VideoItem.brs` | `m.itemSubtitle`/`m.itemThirdTitle` nil in `GlobalSettings` | `if m.itemSubtitle = invalid or m.itemThirdTitle = invalid then return` |
| `settings.brs` | `content.getChild(checkedItem).id` in `radioSettingChanged` with no nil-check on the result | Extract to `selectedOption`, guard with `if selectedOption = invalid then return` |
| `AnalyticsTask.bs` | `CreateObject("roUrlTransfer")` result used without nil-check in `postToPostHog` | `if transfer = invalid then return` |
| `GetTwitchContent.brs` | Same `roUrlTransfer` pattern in `isUrlAccessible` | `if req = invalid then return false` |
| `home.bs` | `liveUser.node.stream` accessed before checking `liveUser.node` in `extractLiveFollows` | `if liveUser.node = invalid then continue for` |
| `user.bs` | `edge.node.id` accessed without nil-check in bookmark loop | `if edge.node = invalid then continue for` |

## Reference

- PostHog error: 1,160 occurrences, 746 users, first seen 2 days after 2.4.0 launch
- Roku crash log CSV: 24 distinct 2.4.0 crash signatures across multiple Roku OS generations (G0–G2)
- `Browse.brs` is the only existing `handleItemSelected` with correct nil-check guards — used as the reference pattern throughout