### PR TITLE
chore: release 2.5.0

### DIFF
--- a/components/Scenes/Settings/settings.xml
+++ b/components/Scenes/Settings/settings.xml
@@ -29,7 +29,7 @@
                 id="detailsCard"
                 translation="[620, 20]"
                 width="600"
-                height="400"
+                height="600"
                 color="0x18181bFF"
                 opacity="0.95"
                 />
@@ -48,14 +48,15 @@
                         <ContentNode title="Enabled" />
                     </ContentNode>
                 </RadioButtonList>
-                <Poster
-                    id="supportQrPoster"
-                    uri="pkg:/images/qr_buymeacoffee.png"
-                    width="240"
-                    height="240"
-                    visible="false"
-                    />
             </LayoutGroup>
+            <Poster
+                id="supportQrPoster"
+                translation="[800, 230]"
+                uri="pkg:/images/qr_buymeacoffee.png"
+                width="240"
+                height="240"
+                visible="false"
+                />
             <RadioButtonList id="radioSetting" translation="[650, 200]" visible="false"
                 inheritParentTransform="false" vertFocusAnimationStyle="floatingFocus" />
 

--- a/manifest
+++ b/manifest
@@ -1,8 +1,8 @@
 title=Stitch-Revitalized
 
 major_version=2
-minor_version=4
-build_version=1
+minor_version=5
+build_version=0
 mm_icon_focus_hd=pkg:/images/channel-poster_hd.png
 mm_icon_focus_sd=pkg:/images/channel-poster_sd.png
 mm_icon_focus_fhd=pkg:/images/channel-poster_fhd.png

--- a/source/changelog.brs
+++ b/source/changelog.brs
@@ -3,6 +3,12 @@
 ' Versions are displayed in ascending order; multiple versions are shown when the user skipped an update.
 function getChangelog() as object
     return {
+        "2.5.0": [
+            "New: Reduced stream latency — streams now start closer to real-time, though zero-delay streaming isn't possible on Roku",
+            "New: Donate via Buy Me a Coffee — find the QR code in Settings",
+            "Fix: Focus highlight now visible on channel pages and all grid views",
+            "Fix: Error tracking now includes more detail to help diagnose crashes faster"
+        ],
         "2.4.0": [
             "New: Following + Browse — simpler 2-tab layout (was 4 tabs)",
             "New: Recently Watched sidebar — quickly rejoin streams you've been to",


### PR DESCRIPTION
## 2.5.0

### What's New
- Reduced stream latency — streams now start closer to real-time, though zero-delay streaming isn't possible on Roku
- Donate via Buy Me a Coffee — find the QR code in Settings

### Fixes
- Focus highlight now visible on channel pages and all grid views
- Error tracking now includes more detail to help diagnose crashes faster

### Changes
- Bump version to 2.5.0
- Add 2.5.0 changelog entry