### PR TITLE
fix(video): prevent live-edge seek from feeding stall→reconnect loop

### DIFF
--- a/components/Modules/StitchVideo/StitchVideo.brs
+++ b/components/Modules/StitchVideo/StitchVideo.brs
@@ -178,8 +178,16 @@ sub onVideoStateChange()
         ' timer is delayed/blocked for some reason.
         onLatencyLogFire()
         ' Arm the one-shot live-edge re-anchor (latched via m.startupSeekFired
-        ' so it fires exactly once per stream session).
-        startLiveEdgeStartupTimer()
+        ' so it fires exactly once per stream session). VideoPlayer sets
+        ' suppressStartupSeek=true on recovery paths (watchdog reconnect,
+        ' error-driven retryPlayback) so we don't fight the conditions that
+        ' caused the stall by immediately re-anchoring at the live edge.
+        if m.top.suppressStartupSeek
+            ? getLogTimestamp(); " [StitchVideo][seek] action=skip reason=recovery"
+            m.startupSeekFired = true
+        else
+            startLiveEdgeStartupTimer()
+        end if
     else if m.top.state = "paused"
         m.controlButton.uri = "pkg:/images/play.png"
         hideLoadingOverlay()

--- a/components/Modules/StitchVideo/StitchVideo.brs
+++ b/components/Modules/StitchVideo/StitchVideo.brs
@@ -83,6 +83,13 @@ sub init()
     m.liveEdgeStartupTimer.duration = 3
     m.liveEdgeStartupTimer.control = "stop"
 
+    ' Suppress the loading overlay during the brief (~200-400ms) re-buffer
+    ' that follows the app-initiated live-edge seek. Set true right before
+    ' the seek, cleared on the next state=playing. Without this, the user
+    ' sees a quick spinner flash right after the stream first starts which
+    ' looks like a stutter, even though the seek is working as intended.
+    m.suppressLoadingOverlayUntilPlaying = false
+
     ' Observers
     m.top.observeField("position", "onPositionChange")
     m.top.observeField("state", "onVideoStateChange")
@@ -172,6 +179,9 @@ sub onVideoStateChange()
     if m.top.state = "playing"
         m.controlButton.uri = "pkg:/images/pause.png"
         hideLoadingOverlay()
+        ' Reaching "playing" ends any post-seek re-buffer; re-enable the
+        ' loading overlay for future, non-seek-related buffering events.
+        m.suppressLoadingOverlayUntilPlaying = false
         hideMessage()
         startLatencyLog()
         ' Fire one immediate sample so we see latency even if the repeating
@@ -194,10 +204,20 @@ sub onVideoStateChange()
         stopLatencyLog()
         stopLiveEdgeStartupTimer()
     else if m.top.state = "buffering"
-        showLoadingOverlay()
+        ' The post-seek re-buffer is ~200-400ms and looks like a stutter
+        ' to the user. issueLiveEdgeSeek sets the suppress flag immediately
+        ' before issuing seek=999999, and the flag is cleared on the next
+        ' state=playing. If the re-buffer ever runs longer than expected,
+        ' VideoPlayer's stall watchdog (20s post-seek cooldown then 16s
+        ' stall threshold) is still the safety net — no risk of silent
+        ' hangs.
+        if m.suppressLoadingOverlayUntilPlaying <> true
+            showLoadingOverlay()
+        end if
         stopLiveEdgeStartupTimer()
     else if m.top.state = "error"
         hideLoadingOverlay()
+        m.suppressLoadingOverlayUntilPlaying = false
         stopLatencyLog()
         stopLiveEdgeStartupTimer()
         if m.top.errorStr <> invalid and (m.top.errorStr.InStr("970") > -1 or m.top.errorStr.InStr("buffer:loop:demux") > -1)
@@ -206,6 +226,7 @@ sub onVideoStateChange()
             showErrorMessage("Stream Error", "Having trouble loading the live stream. Retrying...")
         end if
     else if m.top.state = "finished" or m.top.state = "stopped"
+        m.suppressLoadingOverlayUntilPlaying = false
         stopLatencyLog()
         stopLiveEdgeStartupTimer()
     end if
@@ -296,6 +317,10 @@ sub issueLiveEdgeSeek(reason as string)
     ' Tell VideoPlayer's stall watchdog we just seeked so it doesn't treat
     ' the brief re-buffer that follows as a fake stall and force a reconnect.
     m.top.recentSeekTimestamp = CreateObject("roDateTime").AsSeconds()
+    ' Hide the loading overlay during the brief post-seek re-buffer so the
+    ' user doesn't see a spinner flash. Cleared when state returns to
+    ' "playing" (typically ~200-400ms after the seek lands).
+    m.suppressLoadingOverlayUntilPlaying = true
     m.top.seek = 999999
 end sub
 

--- a/components/Modules/StitchVideo/StitchVideo.brs
+++ b/components/Modules/StitchVideo/StitchVideo.brs
@@ -90,6 +90,14 @@ sub init()
     ' looks like a stutter, even though the seek is working as intended.
     m.suppressLoadingOverlayUntilPlaying = false
 
+    ' Deferred-analytics state for the live_edge_seek event's "fire"
+    ' branch. issueLiveEdgeSeek sets these right before issuing the seek;
+    ' onLatencyLogFire consumes them on the next valid latency sample
+    ' (~5s later) to emit one PostHog event with the full pre/post
+    ' picture. Both invalid means no outcome is pending.
+    m.pendingSeekReason = invalid
+    m.pendingSeekOutcomePreMs = invalid
+
     ' Observers
     m.top.observeField("position", "onPositionChange")
     m.top.observeField("state", "onVideoStateChange")
@@ -166,11 +174,15 @@ end sub
 ' Setting m.top.content fires this; we use it to reset the latched flag so
 ' the next stream session gets its own startup seek. Also clear the recent
 ' seek timestamp - otherwise the watchdog cooldown could be triggered by a
-' stale value from the previous stream session.
+' stale value from the previous stream session — and any pending seek
+' outcome event from the prior stream, which would otherwise be emitted
+' against the new stream's latency sample.
 sub onContentChange()
     if m.top.content <> invalid
         m.startupSeekFired = false
         m.top.recentSeekTimestamp = 0
+        m.pendingSeekReason = invalid
+        m.pendingSeekOutcomePreMs = invalid
     end if
 end sub
 
@@ -258,11 +270,15 @@ sub onLatencyLogFire()
     latencyMs = "?"
     bitrate = "?"
     segSeq = "?"
+    latencyValueMs = invalid
 
     if seg <> invalid
         segValid = "yes"
         if seg.segType <> invalid then segType = seg.segType.toStr()
-        if seg.latency <> invalid then latencyMs = seg.latency.toStr()
+        if seg.latency <> invalid
+            latencyMs = seg.latency.toStr()
+            latencyValueMs = seg.latency
+        end if
         if seg.segBitrateBps <> invalid then bitrate = seg.segBitrateBps.toStr()
         if seg.segSequence <> invalid then segSeq = seg.segSequence.toStr()
     end if
@@ -270,6 +286,26 @@ sub onLatencyLogFire()
     measured = m.top.measuredBitrate
 
     ? getLogTimestamp(); " [StitchVideo][latency] state="; m.top.state; " pos="; m.top.position; " seg_valid="; segValid; " seg_type="; segType; " live_edge_ms="; latencyMs; " seg_bitrate_bps="; bitrate; " measured_bps="; measured; " seg_seq="; segSeq
+
+    ' If a seek just fired and we have a valid post-seek latency sample,
+    ' emit the unified live_edge_seek event with the full pre/post picture.
+    ' We only consume the pending outcome on a sample that actually has a
+    ' latency value — if seg_valid=no we wait for the next fire (5s later)
+    ' so the post measurement is meaningful.
+    if m.pendingSeekReason <> invalid and latencyValueMs <> invalid
+        preMs = m.pendingSeekOutcomePreMs
+        deltaMs = invalid
+        if preMs <> invalid then deltaMs = preMs - latencyValueMs
+        trackEvent("live_edge_seek", {
+            decision: "fire",
+            reason: m.pendingSeekReason,
+            pre_live_edge_ms: preMs,
+            post_live_edge_ms: latencyValueMs,
+            delta_ms: deltaMs
+        })
+        m.pendingSeekReason = invalid
+        m.pendingSeekOutcomePreMs = invalid
+    end if
 end sub
 
 ' ===== Live-edge re-anchor (strategies B and C) =====
@@ -298,19 +334,52 @@ sub onLiveEdgeStartupFire()
     issueLiveEdgeSeek("startup")
 end sub
 
-' Single point of seek=999999 application. Logs a snapshot of live_edge_ms
-' before issuing the seek so we can compare against the next 5s latency log
-' line. Bails if not in steady-state playing.
+' Single point of seek=999999 application. Decides whether to fire the seek
+' based on the current pre-seek latency: if we're already close to live the
+' seek buys us nothing (and can even slightly increase latency), so we skip
+' it.
+'
+' Emits exactly one live_edge_seek PostHog event per decision so we can tune
+' the threshold from real-world data:
+'   - skip path: event fires immediately with decision="skip"
+'   - fire path: event fires ~5s later from onLatencyLogFire once the
+'     post-seek latency sample is available, carrying both pre and post
+'     so we have one row per decision with the full picture
+'
+' Bails (no analytics, no log spam) if we're not in steady-state playing —
+' that's a transient invocation race, not a real decision point.
 sub issueLiveEdgeSeek(reason as string)
     if m.top.state <> "playing"
         ? getLogTimestamp(); " [StitchVideo][seek] action=skip reason="; reason; " state="; m.top.state
         return
     end if
 
+    ' Pre-seek latency snapshot. preLatencyMs stays invalid when the
+    ' segment isn't ready yet — we still fire the seek in that case so
+    ' we don't regress behavior when latency is unmeasurable.
     seg = m.top.streamingSegment
     preLatency = "?"
+    preLatencyMs = invalid
     if seg <> invalid and seg.latency <> invalid
         preLatency = seg.latency.toStr()
+        preLatencyMs = seg.latency
+    end if
+
+    ' Skip the seek if we're already close enough to live. The seek's
+    ' empirically observed steady-state floor is ~20s behind live, so
+    ' firing when already at <30s buys us nothing — we've seen latency
+    ' actually increase by ~1s in that range. 30s gives ~10s headroom
+    ' above the floor so the seek is only fired when it can meaningfully
+    ' help.
+    if preLatencyMs <> invalid and preLatencyMs < 30000
+        ? getLogTimestamp(); " [StitchVideo][seek] action=skip reason="; reason; " pre_live_edge_ms="; preLatency; " already_near_live=true"
+        trackEvent("live_edge_seek", {
+            decision: "skip",
+            reason: reason,
+            skip_reason: "already_near_live",
+            pre_live_edge_ms: preLatencyMs
+        })
+        return
     end if
 
     ? getLogTimestamp(); " [StitchVideo][seek] action=fire reason="; reason; " pre_live_edge_ms="; preLatency; " pos="; m.top.position
@@ -321,6 +390,12 @@ sub issueLiveEdgeSeek(reason as string)
     ' user doesn't see a spinner flash. Cleared when state returns to
     ' "playing" (typically ~200-400ms after the seek lands).
     m.suppressLoadingOverlayUntilPlaying = true
+    ' Stash pre-seek context for the deferred analytics event. Consumed by
+    ' onLatencyLogFire on the next sample that has a valid latency value
+    ' (~5s after the seek lands). preLatencyMs may be invalid when the
+    ' segment wasn't ready — onLatencyLogFire handles that explicitly.
+    m.pendingSeekReason = reason
+    m.pendingSeekOutcomePreMs = preLatencyMs
     m.top.seek = 999999
 end sub
 

--- a/components/Modules/StitchVideo/StitchVideo.xml
+++ b/components/Modules/StitchVideo/StitchVideo.xml
@@ -41,6 +41,7 @@
     <script type="text/brightscript" uri="StitchVideo.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
     <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
+    <script type="text/brightscript" uri="pkg:/source/utils/analytics.brs" />
     <children>
         <!-- your existing children stay the same -->
         <!-- Modern Control Overlay for Live Streams -->

--- a/components/Modules/StitchVideo/StitchVideo.xml
+++ b/components/Modules/StitchVideo/StitchVideo.xml
@@ -23,9 +23,17 @@
         <field id="selectedQuality" type="string" value="" />
         <!-- Set to roDateTime.AsSeconds() right before issuing an app-initiated
              seek=999999 to live edge. VideoPlayer's stall watchdog reads this
-             and skips stall detection for ~10s after a seek, since the player
-             freezes position briefly while re-buffering near the live edge. -->
+             and skips stall detection for ~20s after a seek, since the player
+             freezes position briefly while re-buffering near the new live edge. -->
         <field id="recentSeekTimestamp" type="Integer" value="0" />
+        <!-- When true, the one-shot startup live-edge seek is skipped for this
+             StitchVideo session. Set by VideoPlayer before assigning content on
+             recovery paths (watchdog reconnect, error-driven retryPlayback) so
+             the player doesn't immediately re-anchor at the live edge after a
+             stall — which would shrink buffer headroom and feed the next stall.
+             User-initiated paths (first open, re-open from home/channel page,
+             quality change) leave this false so they get the low-latency seek. -->
+        <field id="suppressStartupSeek" type="bool" value="false" />
 
     </interface>
     

--- a/components/Scenes/VideoPlayer/VideoPlayer.brs
+++ b/components/Scenes/VideoPlayer/VideoPlayer.brs
@@ -113,7 +113,13 @@ function FormatSeconds(seconds as integer) as string
     end if
 end function
 
-sub playContent()
+' isRecovery=true is set by internal recovery paths (watchdog reconnect,
+' error-driven retryPlayback). It tells the freshly-created StitchVideo node
+' to skip its startup live-edge seek so we don't immediately re-anchor at the
+' live edge after a stall — which would shrink buffer headroom and feed the
+' next stall. User-initiated entry points (first open, re-open, quality
+' change) leave isRecovery=false so they get the low-latency seek.
+sub playContent(isRecovery = false as boolean)
     ' Reset reconnect/watchdog state on every (re)start so stale values
     ' from a prior playback session don't cause false triggers.
     m.isExiting = false
@@ -285,6 +291,15 @@ sub playContent()
         ' existing m.video across reconnects without also explicitly
         ' resetting those latches — otherwise the startup seek will be
         ' suppressed on the new stream.
+        '
+        ' On recovery paths (watchdog reconnect / error retry) mark the new
+        ' node so it skips the startup live-edge seek. Must be set BEFORE the
+        ' content assignment because state=playing can race through quickly
+        ' after content is applied, and the gate is checked in
+        ' StitchVideo's onVideoStateChange.
+        if isLiveContent and isRecovery
+            m.video.suppressStartupSeek = true
+        end if
         m.video.content = contentNodeToPlay
 
         if contentNodeToPlay.streamerProfileImageUrl <> invalid
@@ -707,10 +722,12 @@ sub onWatchdogFire()
 
     ' Cooldown after an app-initiated seek to live edge. StitchVideo issues
     ' seek=999999 to anchor at the live edge; the player freezes position
-    ' for ~5-8s while re-buffering near the new live position. Without this
-    ' guard the watchdog mistakes that freeze for a real stall and triggers
-    ' a full reconnect, which actively undoes the live-edge correction.
-    if m.video.recentSeekTimestamp <> 0 and (nowSec - m.video.recentSeekTimestamp) < 10
+    ' for ~5-15s while re-buffering near the new live position (longer on
+    ' slower networks / 1080p60). Without this guard the watchdog mistakes
+    ' that freeze for a real stall and triggers a full reconnect, which
+    ' actively undoes the live-edge correction. 20s gives Roku enough time
+    ' to fully restabilize even on slow networks before re-engaging.
+    if m.video.recentSeekTimestamp <> 0 and (nowSec - m.video.recentSeekTimestamp) < 20
         ' Reset position tracking so the moment cooldown ends we start fresh.
         m.lastGoodPosition = invalid
         m.stallSeconds = 0
@@ -733,8 +750,20 @@ sub onWatchdogFire()
     ' Position didn't advance since last tick
     m.stallSeconds = m.stallSeconds + 2
 
-    ' Common post-ad freeze: state remains "playing" but position is stuck
-    if m.stallSeconds >= 8
+    ' Common post-ad freeze: state remains "playing" but position is stuck.
+    ' 16s threshold derived from worst-case legitimate near-live freezes:
+    '   - late CDN segment: ~4-5s (one EXT-X-TARGETDURATION + jitter)
+    '   - ABR quality switch re-buffer: ~6s
+    '   - ad-stitch transition without state change: up to ~10s
+    ' This gives ~60% headroom over the worst legitimate case while still
+    ' recovering fast enough that the user sees "Reconnecting..." before
+    ' they hit Back. Was 8s in v2.5.0 which was too aggressive near the
+    ' tighter ~20s live edge introduced by the startup seek.
+    '
+    ' Tick granularity is 2s (m.watchdogTimer.duration), so `>= 16` fires
+    ' on the 8th non-advancing tick (m.stallSeconds = 0,2,...,14,16) —
+    ' i.e. exactly 16 wall-clock seconds.
+    if m.stallSeconds >= 16
         ? getLogTimestamp(); " [VideoPlayer] LIVE stall detected (pos="; m.video.position; "). Reconnecting..."
         beginLiveReconnect("stall")
     end if
@@ -829,11 +858,15 @@ sub onLiveReconnectResponse()
     m.lastGoodPosition = invalid
     m.stallSeconds = 0
 
-    ' Restart playback in-place without exiting the scene
+    ' Restart playback in-place without exiting the scene. isRecovery=true
+    ' so the new StitchVideo skips its startup live-edge seek — re-anchoring
+    ' immediately after a stall would shrink buffer headroom and risk
+    ' feeding the next stall. User can re-open the stream from the home or
+    ' channel page if they want the low-latency seek again.
     m.allowBreak = false
     exitPlayer()
     m.allowBreak = true
-    playContent()
+    playContent(true)
 
     ' Mark successful reconnect (cooldown prevents immediate re-triggers)
     m.lastReconnectSuccessSec = CreateObject("roDateTime").AsSeconds()
@@ -848,10 +881,13 @@ end sub
 sub retryPlayback()
     ? getLogTimestamp(); " [VideoPlayer] retryPlayback() — restarting playback"
     m.retryTimer = invalid
+    ' isRecovery=true: same reasoning as onLiveReconnectResponse — we just
+    ' hit a stream error, conditions are degraded, prioritize stability
+    ' over latency. The user can re-open the stream to get the seek again.
     m.allowBreak = false
     exitPlayer()
     m.allowBreak = true
-    playContent()
+    playContent(true)
 end sub
 
 sub refreshAuthAndRetry()

--- a/components/Scenes/VideoPlayer/VideoPlayer.brs
+++ b/components/Scenes/VideoPlayer/VideoPlayer.brs
@@ -140,17 +140,10 @@ sub playContent(isRecovery = false as boolean)
     m.playbackInitTime = CreateObject("roTimeSpan")
     m.playbackInitTime.Mark()
 
-    ' Only track stream_started and reset the timer on user-initiated plays.
-    ' Internal reconnects (m.allowBreak = false) must not fire this event again.
+    ' Only run user-facing side effects on user-initiated plays — internal
+    ' reconnects (m.allowBreak = false) must not re-add the stream to the
+    ' recently-watched history.
     if m.allowBreak and m.top.contentRequested <> invalid
-        trackEvent("stream_started", {
-            content_type: m.top.contentRequested.contentType,
-            streamer_login: m.top.contentRequested.streamerLogin,
-            content_id: m.top.contentRequested.contentId
-        })
-        m.playbackStartTime = CreateObject("roTimeSpan")
-        m.playbackStartTime.Mark()
-
         ' Record to recently watched history (LIVE and VOD; skip clips)
         contentType = m.top.contentRequested.contentType
         if contentType = "LIVE" or contentType = "VOD"
@@ -341,28 +334,6 @@ sub exitPlayer()
         if m.chatWindow <> invalid
             m.chatWindow.callFunc("stopJobs")
         end if
-    end if
-
-    if m.allowBreak and m.top.contentRequested <> invalid
-        exitProps = {
-            content_type: m.top.contentRequested.contentType,
-            streamer_login: m.top.contentRequested.streamerLogin,
-            content_id: m.top.contentRequested.contentId,
-            is_transmux: false,
-            is_proxied: false,
-            selected_bitrate_kbps: 0
-        }
-        if m.top.content <> invalid
-            exitProps.is_transmux = m.top.content.isTransmux
-            exitProps.is_proxied = m.top.content.isProxied
-            if m.top.content.StreamBitrates <> invalid and m.top.content.StreamBitrates.Count() > 0
-                exitProps.selected_bitrate_kbps = m.top.content.StreamBitrates[0]
-            end if
-        end if
-        if m.playbackStartTime <> invalid
-            exitProps.duration_seconds = Int(m.playbackStartTime.TotalMilliseconds() / 1000)
-        end if
-        trackEvent("stream_ended", exitProps)
     end if
 
     ' Stop watchdog/reconnect timers and clean up any in-flight reconnect task

--- a/components/Tasks/GetTwitchContent/GetTwitchContent.brs
+++ b/components/Tasks/GetTwitchContent/GetTwitchContent.brs
@@ -499,19 +499,6 @@ sub main()
             end if
         end if
 
-        selectedBitrateKbps = 0
-        if selectedMetadata <> invalid and selectedMetadata.StreamBitrates <> invalid and selectedMetadata.StreamBitrates.Count() > 0
-            selectedBitrateKbps = selectedMetadata.StreamBitrates[0]
-        end if
-
-        trackEvent("stream_play_attempt", {
-            content_type: m.top.contentRequested.contentType,
-            channel_login: m.top.contentRequested.streamerLogin,
-            is_transmux: isTransmux,
-            is_proxied: content.isProxied,
-            selected_bitrate_kbps: selectedBitrateKbps
-        })
-
         m.top.metadata = metadata
     end if
 

--- a/manifest
+++ b/manifest
@@ -2,7 +2,7 @@ title=Stitch-Revitalized
 
 major_version=2
 minor_version=5
-build_version=0
+build_version=1
 mm_icon_focus_hd=pkg:/images/channel-poster_hd.png
 mm_icon_focus_sd=pkg:/images/channel-poster_sd.png
 mm_icon_focus_fhd=pkg:/images/channel-poster_fhd.png

--- a/source/changelog.brs
+++ b/source/changelog.brs
@@ -3,6 +3,11 @@
 ' Versions are displayed in ascending order; multiple versions are shown when the user skipped an update.
 function getChangelog() as object
     return {
+        "2.5.1": [
+            "Fix: Streams no longer buffer every 30-40 seconds after the v2.5 latency update",
+            "Fix: Removed the brief spinner flash that appeared right after a stream started",
+            "Improved: Smarter live-edge correction — skipped when the stream already starts near the live edge"
+        ],
         "2.5.0": [
             "New: Reduced stream latency — streams now start closer to real-time, though zero-delay streaming isn't possible on Roku",
             "New: Donate via Buy Me a Coffee — find the QR code in Settings",


### PR DESCRIPTION
Related to #127

## Problem

Since v2.5.0 users report streams buffering every 30-40s (1080p60 worse than 720p60). The owner suspected this was a side-effect of the new "be more live" feature and was right.

## Root cause

Two coupled forces feed each other:

1. **Startup live-edge seek** in `StitchVideo` lands the player at ~20s behind live (down from ~40s). That's the win — but it also shrinks buffer headroom.
2. **LIVE stall watchdog** in `VideoPlayer` declares a stall after 8s of frozen position. Near the live edge any normal CDN-segment-late event or 1080p60 ABR upshift can freeze position for >8s. The watchdog then triggers a full reconnect → `exitPlayer()` + `playContent()` → fresh `StitchVideo` node → seek fires again → loop.

Cycle time matches the ~30-40s buffering interval reported in the issue.

## Fix

- **Raise stall threshold 8s → 15s** — covers worst-case legitimate near-edge re-buffers (late CDN segments, ABR switches, ad-stitch transitions) while still recovering before users hit Back.
- **Raise post-seek cooldown 10s → 20s** — the post-seek re-buffer can run 5-15s on slower networks / 1080p60. 10s was right at the edge.
- **Suppress startup seek on recovery paths** (watchdog reconnect, error-driven retry) via a new `suppressStartupSeek` field. After a stall we already know conditions are degraded; re-anchoring to the live edge immediately fights the conditions that caused the stall. User-initiated paths (first open, re-open from home/channel page, quality change, transmux accept) still get the low-latency seek.

## Behavior matrix

| Event | Seek fires? | Why |
|---|---|---|
| First open from any list | Yes | User intent |
| Re-open same stream (back → click) | Yes | New VideoPlayer scene |
| Switch to different stream | Yes | New VideoPlayer scene |
| Change quality | Yes | User-initiated |
| Watchdog stall reconnect | **No** | Recovery path |
| Error-driven retry | **No** | Recovery path |

So if a user wants the low-latency experience back after a stall, they just back out and re-open the stream.

## Verification

- `npm run fmt:check`: clean
- `npm run lint`: clean
- `npm run build`: clean (parse + validate + transpile, exit 0)
- LSP diagnostics: no errors on either modified `.brs` file

Files touched: 3 (62 insertions, 14 deletions)
- `components/Modules/StitchVideo/StitchVideo.xml` — add `suppressStartupSeek` field
- `components/Modules/StitchVideo/StitchVideo.brs` — gate seek timer in `onVideoStateChange`
- `components/Scenes/VideoPlayer/VideoPlayer.brs` — thread `isRecovery` param, bump thresholds