### PR TITLE
chore: RSG 1.3 compliance

### DIFF
--- a/components/Modules/StitchVideo/StitchVideo.brs
+++ b/components/Modules/StitchVideo/StitchVideo.brs
@@ -41,7 +41,7 @@ sub init()
     ' Quality dialog
     m.qualityDialog = m.top.findNode("QualityDialog")
     ' Set up quality dialog observer once during initialization
-    m.qualityDialog.observeFieldScoped("buttonSelected", "onQualityButtonSelect")
+    m.qualityDialog.observeFieldScopedEx("buttonSelected", "onQualityButtonSelect")
 
     ' State variables
     m.currentFocusedButton = 2 ' 0=back, 1=chat, 2=play/pause, 3=quality

--- a/manifest
+++ b/manifest
@@ -13,5 +13,7 @@ splash_screen_fhd=pkg:/images/splash-screen_fhd.png
 splash_screen_4k=pkg:/images/splash-screen_4k.png
 
 supports_input_launch=1
+rsg_version=1.3
+firmware_version=15.1
 
 ui_resolutions=hd


### PR DESCRIPTION
## Summary

Addresses two static analysis warnings from the Roku channel store.

### Changes

**manifest**
- Added `rsg_version=1.3` — required for channel store certification (mandatory after Oct 1, 2026)
- Added `firmware_version=15.1` — minimum firmware required by RSG 1.3

**StitchVideo.brs**
- Migrated `observeFieldScoped()` → `observeFieldScopedEx()`, which is the recommended replacement as of Roku OS 15.1
- Teardown remains `unobserveFieldScoped()` — no `unobserveFieldScopedEx` variant exists in the SDK

### Notes
RSG 1.3 is purely additive (no breaking changes). These are the only changes needed for full compliance.