### PR TITLE
fix: v2.5.0 crash guards (ChannelPage, GamePage, EmojiLabel, Search)

### DIFF
--- a/components/Modules/EmojiLabel/EmojiLabel.brs
+++ b/components/Modules/EmojiLabel/EmojiLabel.brs
@@ -23,11 +23,14 @@ sub init()
     m.top.observeField("emojiSize", "updateComponents")
     m.top.observeField("maxWidth", "updateComponents")
     m.timer = m.top.findNode("timer")
-    m.timer.observeField("fire", "onTimerFireChange")
+    if m.timer <> invalid
+        m.timer.observeField("fire", "onTimerFireChange")
+    end if
     setText()
 end sub
 
 sub onTimerFireChange() as void
+    if m.animation = invalid or m.timer = invalid then return
     m.animation.repeat = false
     m.animation.control = "stop"
     m.components.translation = [0, 0]
@@ -35,6 +38,7 @@ sub onTimerFireChange() as void
 end sub
 
 sub doScroll()
+    if m.animation = invalid or m.timer = invalid then return
     if m.top.repeatCount <> invalid
         if m.top.repeatCount <> 0
             m.animation.repeat = true

--- a/components/Modules/EmojiLabel/EmojiLabel.brs
+++ b/components/Modules/EmojiLabel/EmojiLabel.brs
@@ -116,9 +116,15 @@ sub updateComponents()
         if m.top.maxWidth = 0
             m.top.maxWidth = m.top.width
         end if
-        m.animation.duration = (m.top.width / m.top.maxWidth)
-        m.timer.duration = (m.top.width / m.top.maxWidth)
-        m.vector.keyValue = [[0, 0], [innerWidth, 0]]
+        if m.animation <> invalid
+            m.animation.duration = (m.top.width / m.top.maxWidth)
+        end if
+        if m.timer <> invalid
+            m.timer.duration = (m.top.width / m.top.maxWidth)
+        end if
+        if m.vector <> invalid
+            m.vector.keyValue = [[0, 0], [innerWidth, 0]]
+        end if
 
         if m.top.emojiSize > height
             height = m.top.emojiSize

--- a/components/Scenes/ChannelPage/ChannelPage.brs
+++ b/components/Scenes/ChannelPage/ChannelPage.brs
@@ -124,6 +124,7 @@ sub updateRowList(contentCollection)
 end sub
 
 sub handleItemSelected()
+    if m.rowlist.content = invalid then return
     selectedRow = m.rowlist.content.getChild(m.rowlist.rowItemSelected[0])
     if selectedRow = invalid then return
     selectedItem = selectedRow.getChild(m.rowlist.rowItemSelected[1])

--- a/components/Scenes/GamePage/GamePage.brs
+++ b/components/Scenes/GamePage/GamePage.brs
@@ -22,7 +22,7 @@ function buildContentNodeFromShelves(streams)
             row = createObject("RoSGNode", "ContentNode")
         end if
         stream = streams[i]
-        if stream = invalid or stream.node = invalid then continue for
+        if stream = invalid or stream.node = invalid or stream.node.broadcaster = invalid then continue for
         row.title = ""
         rowItem = createObject("RoSGNode", "TwitchContentNode")
         rowItem.contentId = stream.node.Id

--- a/components/Scenes/Search/Search.brs
+++ b/components/Scenes/Search/Search.brs
@@ -88,10 +88,11 @@ sub buildContentNodeFromShelves(shelves)
             rowItem.contentType = "USER"
         end if
         if rowItem.contentType = "LIVE"
+            if item.stream.broadcaster = invalid then continue for
             rowItem.contentId = item.stream.Id
             rowItem.createdAt = item.stream.createdAt
             rowItem.previewImageURL = Substitute("https://static-cdn.jtvnw.net/previews-ttv/live_user_{0}-{1}x{2}.jpg", item.stream.broadcaster.login, "1280", "720")
-            rowItem.contentTitle = item.stream.broadcaster.broadcastSettings.title
+            rowItem.contentTitle = item.stream.broadcaster.broadcastSettings?.title
             rowItem.viewersCount = item.stream.viewersCount
             rowItem.streamerDisplayName = item.stream.broadcaster.displayName
             rowItem.streamerLogin = item.stream.broadcaster.login


### PR DESCRIPTION
## Summary

Fixes 4 crashes identified in v2.5.0 crash logs (05/20), totalling **35 crashes across 26 devices**.

## Crashes Fixed

| File | Function | Root Cause | Crashes | Devices |
|---|---|---|---|---|
| `ChannelPage.brs` | `handleItemSelected()` | `m.rowlist.content` accessed before API response populates it | 14 | 13 |
| `GamePage.brs` | `buildContentNodeFromShelves()` | `stream.node.broadcaster` deep-accessed without nil-check | 14 | 6 |
| `EmojiLabel.brs` | `updateComponents()` | `m.animation`, `m.timer`, `m.vector` not nil-checked (brs-engine findNode quirk) | 5 | 5 |
| `Search.brs` | `buildContentNodeFromShelves()` | `item.stream.broadcaster` and `.broadcastSettings` not nil-checked | 2 | 2 |

## Changes

- **ChannelPage**: Add `if m.rowlist.content = invalid then return` before `getChild()` call
- **GamePage**: Extend `continue for` guard to cover `stream.node.broadcaster`
- **EmojiLabel**: Wrap `m.animation`, `m.timer`, `m.vector` assignments in nil-checks
- **Search**: Guard entire LIVE block on `broadcaster` presence; use optional chaining for `broadcastSettings?.title`

## Not included

VideoItem crash (Priority 1, 78 crashes) — larger refactor of `findNode()` init pattern, tracked separately.