### PR TITLE
fix(fmp4-demux-proxy): pass through MPEG-TS segments instead of demuxing

### DIFF
--- a/fmp4-demux-proxy/src/fmp4_demux_proxy/routes/segment_route.py
+++ b/fmp4-demux-proxy/src/fmp4_demux_proxy/routes/segment_route.py
@@ -107,6 +107,15 @@ async def segment_handler(request: web.Request) -> web.Response:
 
     data = await _fetch_dedup(session, upstream, request.app)
 
+    # MPEG-TS segment (0x47 sync byte, 188-byte packets): not fMP4, pass through.
+    if data[:1] == b"\x47" and (len(data) < 189 or data[188] == 0x47):
+        logger.debug("MPEG-TS segment detected for %s; passing through", upstream)
+        return web.Response(
+            body=data,
+            content_type="video/mp2t",
+            headers={"Cache-Control": "no-store"},
+        )
+
     track_maps = request.app[TRACK_MAP_KEY]
     cache_key = _cache_key(upstream)
     keep: fmp4.TrackKind = "video" if track == "video" else "audio"

--- a/fmp4-demux-proxy/tests/test_routes.py
+++ b/fmp4-demux-proxy/tests/test_routes.py
@@ -233,6 +233,25 @@ class TestSegmentRoute:
         body = await seg_resp.read()
         assert len(body) < len(media_bytes)
 
+    async def test_mpeg_ts_segment_passes_through_despite_cached_map(
+        self, proxy_client: TestClient, upstream: TestServer
+    ) -> None:
+        init_bytes = make_init_segment(traks=[(1, b"soun"), (2, b"vide")])
+        upstream.app["init"] = init_bytes
+        init_url = str(upstream.make_url("/init.mp4"))
+        init_resp = await proxy_client.get(f"/s?u={quote(init_url, safe='')}&k=init&track=video")
+        assert init_resp.status == 200
+        await init_resp.read()
+
+        ts_bytes = (b"\x47\x40\x00\x13" + b"\x00" * 184) * 3
+        upstream.app["media"] = ts_bytes
+        seg_url = str(upstream.make_url("/seg-1.m4s"))
+        resp = await proxy_client.get(f"/s?u={quote(seg_url, safe='')}&k=media&track=video")
+        assert resp.status == 200
+        assert resp.content_type == "video/mp2t"
+        body = await resp.read()
+        assert body == ts_bytes
+
     async def test_media_without_cached_map_passes_through(
         self, proxy_client: TestClient, upstream: TestServer
     ) -> None:


### PR DESCRIPTION
Twitch can serve MPEG-TS segments; the fMP4 parser raised
TruncatedBoxError (0x47 TS sync byte read as box size). Sniff the
sync byte at offsets 0 and 188 and pass through as video/mp2t.
